### PR TITLE
Feat(#57): NCS 직무 정보 및 코드 데이터를 DB에 저장 후 조회 관련 컨트롤러를 작성한다.

### DIFF
--- a/src/main/java/com/dodream/common/infrastructure/mapper/CommonResponseMapper.java
+++ b/src/main/java/com/dodream/common/infrastructure/mapper/CommonResponseMapper.java
@@ -15,7 +15,7 @@ public class CommonResponseMapper {
     private final XmlToJsonConverter xmlToJsonConverter;
     private final ObjectMapper objectMapper;
 
-    public CommonResponse toRegionResponse(String xml) {
+    public CommonResponse toCommonResponse(String xml) {
         String json = xmlToJsonConverter.convertXmlToJson(xml);
         try {
             return objectMapper.readValue(json, CommonResponse.class);

--- a/src/main/java/com/dodream/ncs/application/NcsApiService.java
+++ b/src/main/java/com/dodream/ncs/application/NcsApiService.java
@@ -1,0 +1,35 @@
+package com.dodream.ncs.application;
+
+import com.dodream.common.dto.response.CommonResponse;
+import com.dodream.common.infrastructure.CommonApiCaller;
+import com.dodream.common.infrastructure.mapper.CommonResponseMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NcsApiService {
+
+    private final CommonApiCaller commonApiCaller;
+    private final CommonResponseMapper commonResponseMapper;
+
+    public CommonResponse.SrchList getLargeNcsInfo(){
+        String xml = commonApiCaller.callCommonApi("05", null, null);
+        return commonResponseMapper.toRegionResponse(xml).srchList();
+    }
+
+    public CommonResponse.SrchList getMiddleNcsInfo(){
+        String xml = commonApiCaller.callCommonApi("06", null, null);
+        return commonResponseMapper.toRegionResponse(xml).srchList();
+    }
+
+    public CommonResponse.SrchList getSmallNcsInfo(){
+        String xml = commonApiCaller.callCommonApi("07", null, null);
+        return commonResponseMapper.toRegionResponse(xml).srchList();
+    }
+
+    public CommonResponse.SrchList getSmallestNcsInfo(){
+        String xml = commonApiCaller.callCommonApi("08", null, null);
+        return commonResponseMapper.toRegionResponse(xml).srchList();
+    }
+}

--- a/src/main/java/com/dodream/ncs/application/NcsApiService.java
+++ b/src/main/java/com/dodream/ncs/application/NcsApiService.java
@@ -13,23 +13,24 @@ public class NcsApiService {
     private final CommonApiCaller commonApiCaller;
     private final CommonResponseMapper commonResponseMapper;
 
+    public CommonResponse.SrchList getNcsInfo(String ncsClassCode){
+        String xml = commonApiCaller.callCommonApi(ncsClassCode, null, null);
+        return commonResponseMapper.toCommonResponse(xml).srchList();
+    }
+
     public CommonResponse.SrchList getLargeNcsInfo(){
-        String xml = commonApiCaller.callCommonApi("05", null, null);
-        return commonResponseMapper.toRegionResponse(xml).srchList();
+        return getNcsInfo("05");
     }
 
     public CommonResponse.SrchList getMiddleNcsInfo(){
-        String xml = commonApiCaller.callCommonApi("06", null, null);
-        return commonResponseMapper.toRegionResponse(xml).srchList();
+        return getNcsInfo("06");
     }
 
     public CommonResponse.SrchList getSmallNcsInfo(){
-        String xml = commonApiCaller.callCommonApi("07", null, null);
-        return commonResponseMapper.toRegionResponse(xml).srchList();
+        return getNcsInfo("07");
     }
 
     public CommonResponse.SrchList getSmallestNcsInfo(){
-        String xml = commonApiCaller.callCommonApi("08", null, null);
-        return commonResponseMapper.toRegionResponse(xml).srchList();
+        return getNcsInfo("08");
     }
 }

--- a/src/main/java/com/dodream/ncs/application/NcsService.java
+++ b/src/main/java/com/dodream/ncs/application/NcsService.java
@@ -1,0 +1,37 @@
+package com.dodream.ncs.application;
+
+import com.dodream.ncs.domain.Ncs;
+import com.dodream.ncs.dto.response.NcsResponseDto;
+import com.dodream.ncs.exception.NcsErrorCode;
+import com.dodream.ncs.repository.NcsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NcsService {
+
+    private final NcsRepository ncsRepository;
+
+    public List<NcsResponseDto> getAllNcs(){
+        return ncsRepository.findAll().stream()
+                .map(NcsResponseDto::from)
+                .toList();
+    }
+
+    public NcsResponseDto getNcsByNcsName(String ncsName){
+        Ncs ncs = ncsRepository.findByNcsName(ncsName)
+                .orElseThrow(NcsErrorCode.NOT_FOUND_NCS::toException);
+
+        return NcsResponseDto.from(ncs);
+    }
+
+    public NcsResponseDto getNcsByNcsCode(String ncsCode){
+        Ncs ncs = ncsRepository.findByNcsCode(ncsCode)
+                .orElseThrow(NcsErrorCode.NOT_FOUND_NCS::toException);
+
+        return NcsResponseDto.from(ncs);
+    }
+}

--- a/src/main/java/com/dodream/ncs/domain/NCS.java
+++ b/src/main/java/com/dodream/ncs/domain/NCS.java
@@ -1,0 +1,33 @@
+package com.dodream.ncs.domain;
+
+import com.dodream.core.infrastructure.jpa.entity.BaseLongIdEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Table(name = "ncs")
+public class NCS extends BaseLongIdEntity {
+
+    @Column(name = "ncs_code", nullable = false, unique = true)
+    private String ncsCode;
+
+    @Column(name = "ncs_name", nullable = false)
+    private String ncsName;
+
+    public static NCS of(String ncsCode, String ncsName) {
+        return NCS.builder()
+                .ncsCode(ncsCode)
+                .ncsName(ncsName)
+                .build();
+    }
+}

--- a/src/main/java/com/dodream/ncs/domain/NCS.java
+++ b/src/main/java/com/dodream/ncs/domain/NCS.java
@@ -16,7 +16,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @Table(name = "ncs")
-public class NCS extends BaseLongIdEntity {
+public class Ncs extends BaseLongIdEntity {
 
     @Column(name = "ncs_code", nullable = false, unique = true)
     private String ncsCode;
@@ -24,8 +24,8 @@ public class NCS extends BaseLongIdEntity {
     @Column(name = "ncs_name", nullable = false)
     private String ncsName;
 
-    public static NCS of(String ncsCode, String ncsName) {
-        return NCS.builder()
+    public static Ncs of(String ncsCode, String ncsName) {
+        return Ncs.builder()
                 .ncsCode(ncsCode)
                 .ncsName(ncsName)
                 .build();

--- a/src/main/java/com/dodream/ncs/dto/response/NcsResponseDto.java
+++ b/src/main/java/com/dodream/ncs/dto/response/NcsResponseDto.java
@@ -1,0 +1,15 @@
+package com.dodream.ncs.dto.response;
+
+import com.dodream.ncs.domain.Ncs;
+
+public record NcsResponseDto(
+
+        String ncsCode,
+
+        String ncsName
+) {
+
+    public static NcsResponseDto from(Ncs ncs){
+        return new NcsResponseDto(ncs.getNcsCode(), ncs.getNcsName());
+    }
+}

--- a/src/main/java/com/dodream/ncs/exception/NcsErrorCode.java
+++ b/src/main/java/com/dodream/ncs/exception/NcsErrorCode.java
@@ -1,0 +1,22 @@
+package com.dodream.ncs.exception;
+
+import com.dodream.core.exception.DomainException;
+import com.dodream.core.exception.error.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NcsErrorCode implements BaseErrorCode<DomainException> {
+    NOT_FOUND_NCS(HttpStatus.NOT_FOUND, "NCS 데이터를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/com/dodream/ncs/infrastructure/NcsInitiallizer.java
+++ b/src/main/java/com/dodream/ncs/infrastructure/NcsInitiallizer.java
@@ -1,0 +1,58 @@
+package com.dodream.ncs.infrastructure;
+
+import com.dodream.common.dto.response.CommonResponse;
+import com.dodream.ncs.application.NcsApiService;
+import com.dodream.ncs.domain.Ncs;
+import com.dodream.ncs.repository.NcsRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class NcsInitiallizer {
+
+    private final NcsApiService ncsApiService;
+    private final NcsRepository ncsRepository;
+
+    @PostConstruct
+    public void init() {
+        if(ncsRepository.count() != 0) return;
+
+        log.info("[NcsInitiallizer] - NCS 직무 코드 데이터 저장 시작");
+
+        List<Ncs> largeNcsList = searchResultToNcsList(ncsApiService.getLargeNcsInfo());
+        log.info("[NcsInitiallizer] - 대분류 - {}개 검색", largeNcsList.size());
+
+        List<Ncs> middleNcsList = searchResultToNcsList(ncsApiService.getMiddleNcsInfo());
+        log.info("[NcsInitiallizer] - 중분류 - {}개 검색", middleNcsList.size());
+
+        List<Ncs> smallNcsList = searchResultToNcsList(ncsApiService.getSmallNcsInfo());
+        log.info("[NcsInitiallizer] - 소분류 - {}개 검색", smallNcsList.size());
+
+        List<Ncs> smallestNcsList = searchResultToNcsList(ncsApiService.getSmallestNcsInfo());
+        log.info("[NcsInitiallizer] - 세분류 - {}개 검색", smallestNcsList.size());
+
+        ncsRepository.saveAll(largeNcsList);
+        ncsRepository.saveAll(middleNcsList);
+        ncsRepository.saveAll(smallNcsList);
+        ncsRepository.saveAll(smallestNcsList);
+
+        log.info("[NcsInitiallizer] - NCS 직무 코드 데이터 저장 종료");
+    }
+
+
+    private List<Ncs> searchResultToNcsList(CommonResponse.SrchList srchList){
+        return srchList.scnList()
+                .stream()
+                .map(item -> Ncs.of(
+                        item.rsltCode(),
+                        item.rsltName()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/dodream/ncs/presentation/controller/NcsController.java
+++ b/src/main/java/com/dodream/ncs/presentation/controller/NcsController.java
@@ -4,8 +4,12 @@ import com.dodream.core.presentation.RestResponse;
 import com.dodream.ncs.application.NcsService;
 import com.dodream.ncs.dto.response.NcsResponseDto;
 import com.dodream.ncs.presentation.swagger.NcsSwagger;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/v1/ncs")
 @RequiredArgsConstructor
+@Validated
 public class NcsController implements NcsSwagger {
 
     private final NcsService ncsService;
@@ -30,6 +35,8 @@ public class NcsController implements NcsSwagger {
     @Override
     @GetMapping("/name/{name}")
     public ResponseEntity<RestResponse<NcsResponseDto>> getNcsByName(
+            @Parameter(name = "name", description = "직무 이름 (예시: 철도차량제작)", example = "화학·바이오공통")
+            @NotBlank(message = "직무 이름은 필수입니다")
             @PathVariable String name
     ) {
         return ResponseEntity.ok(new RestResponse<>(ncsService.getNcsByNcsName(name)));
@@ -38,6 +45,12 @@ public class NcsController implements NcsSwagger {
     @Override
     @GetMapping("/code/{code}")
     public ResponseEntity<RestResponse<NcsResponseDto>> getNcsByCode(
+            @Parameter(name = "code",
+                    description = "NCS 직무 코드 -> 대분류(2자리 정수), 중분류(4자리 정수), " +
+                            "소분류(6자리 정수), 세분류(8자리 정수)",
+                    example = "01"
+            )
+            @Pattern(regexp = "^(\\d{2}|\\d{4}|\\d{6}|\\d{8})$", message = "2,4,6,8자리 정수를 입력해 주세요")
             @PathVariable String code
     ) {
         return ResponseEntity.ok(new RestResponse<>(ncsService.getNcsByNcsCode(code)));

--- a/src/main/java/com/dodream/ncs/presentation/controller/NcsController.java
+++ b/src/main/java/com/dodream/ncs/presentation/controller/NcsController.java
@@ -1,0 +1,45 @@
+package com.dodream.ncs.presentation.controller;
+
+import com.dodream.core.presentation.RestResponse;
+import com.dodream.ncs.application.NcsService;
+import com.dodream.ncs.dto.response.NcsResponseDto;
+import com.dodream.ncs.presentation.swagger.NcsSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/v1/ncs")
+@RequiredArgsConstructor
+public class NcsController implements NcsSwagger {
+
+    private final NcsService ncsService;
+
+    @Override
+    @GetMapping("/all")
+    public ResponseEntity<RestResponse<List<NcsResponseDto>>> getAllNcs() {
+        return ResponseEntity.ok(new RestResponse<>(ncsService.getAllNcs()));
+    }
+
+    @Override
+    @GetMapping("/name/{name}")
+    public ResponseEntity<RestResponse<NcsResponseDto>> getNcsByName(
+            @PathVariable String name
+    ) {
+        return ResponseEntity.ok(new RestResponse<>(ncsService.getNcsByNcsName(name)));
+    }
+
+    @Override
+    @GetMapping("/code/{code}")
+    public ResponseEntity<RestResponse<NcsResponseDto>> getNcsByCode(
+            @PathVariable String code
+    ) {
+        return ResponseEntity.ok(new RestResponse<>(ncsService.getNcsByNcsCode(code)));
+    }
+}

--- a/src/main/java/com/dodream/ncs/presentation/swagger/NcsSwagger.java
+++ b/src/main/java/com/dodream/ncs/presentation/swagger/NcsSwagger.java
@@ -1,0 +1,52 @@
+package com.dodream.ncs.presentation.swagger;
+
+import com.dodream.core.config.swagger.ApiErrorCode;
+import com.dodream.core.presentation.RestResponse;
+import com.dodream.ncs.dto.response.NcsResponseDto;
+import com.dodream.ncs.exception.NcsErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "NCS", description = "Ncs 직무 정보(고용 24)관련 검색 API")
+public interface NcsSwagger {
+
+    @Operation(
+            summary = "지역 전체 리스트 검색 API",
+            description = "고용24에서 제공하는 모든 NCS 직무 코드 및 이름을 검색합니다.",
+            operationId = "/v1/ncs/all"
+    )
+    @ApiErrorCode(NcsErrorCode.class)
+    ResponseEntity<RestResponse<List<NcsResponseDto>>> getAllNcs();
+
+    @Operation(
+            summary = "NCS 직무 이름으로 검색하는 API",
+            description = "NCS 직무 이름으로 고용 24에서 제공하는 NCS 직무 코드 및 이름을 검색합니다",
+            operationId = "/v1/ncs/name/{name}"
+    )
+    @ApiErrorCode(NcsErrorCode.class)
+    ResponseEntity<RestResponse<NcsResponseDto>> getNcsByName(
+            @Parameter(name = "name", description = "직무 이름 (예시: 철도차량제작)", example = "화학·바이오공통")
+            @NotBlank(message = "직무 이름은 필수입니다") String name
+    );
+
+    @Operation(
+            summary = "지역 코드로 검색하는 API",
+            description = "NCS 직무 코드로 고용 24에서 제공하는 직무 코드 및 이름을 검색합니다",
+            operationId = "/v1/ncs/code/{code}"
+    )
+    @ApiErrorCode(NcsErrorCode.class)
+    ResponseEntity<RestResponse<NcsResponseDto>> getNcsByCode(
+            @Parameter(name = "code",
+                    description = "NCS 직무 코드 -> 대분류(2자리 정수), 중분류(4자리 정수), " +
+                            "소분류(6자리 정수), 세분류(8자리 정수)",
+                    example = "01"
+            )
+            @Pattern(regexp = "^(\\d{2}|\\d{4}|\\d{6}|\\d{8})$", message = "2,4,6,8자리 정수를 입력해 주세요") String code
+    );
+}

--- a/src/main/java/com/dodream/ncs/presentation/swagger/NcsSwagger.java
+++ b/src/main/java/com/dodream/ncs/presentation/swagger/NcsSwagger.java
@@ -17,7 +17,7 @@ import java.util.List;
 public interface NcsSwagger {
 
     @Operation(
-            summary = "지역 전체 리스트 검색 API",
+            summary = "NCS 전체 리스트 검색 API",
             description = "고용24에서 제공하는 모든 NCS 직무 코드 및 이름을 검색합니다.",
             operationId = "/v1/ncs/all"
     )
@@ -36,7 +36,7 @@ public interface NcsSwagger {
     );
 
     @Operation(
-            summary = "지역 코드로 검색하는 API",
+            summary = "NCS 코드로 검색하는 API",
             description = "NCS 직무 코드로 고용 24에서 제공하는 직무 코드 및 이름을 검색합니다",
             operationId = "/v1/ncs/code/{code}"
     )

--- a/src/main/java/com/dodream/ncs/repository/NcsRepository.java
+++ b/src/main/java/com/dodream/ncs/repository/NcsRepository.java
@@ -1,0 +1,13 @@
+package com.dodream.ncs.repository;
+
+import com.dodream.ncs.domain.Ncs;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NcsRepository extends JpaRepository<Ncs, Integer> {
+
+    Optional<Ncs> findByNcsName(String ncsName);
+
+    Optional<Ncs> findByNcsCode(String ncsCode);
+}

--- a/src/main/java/com/dodream/region/application/RegionApiService.java
+++ b/src/main/java/com/dodream/region/application/RegionApiService.java
@@ -22,7 +22,7 @@ public class RegionApiService {
 
     public CommonResponse.SrchList getLargeRegionCode() {
         String xml = commonApiCaller.callCommonApi("00", null, null);
-        return commonResponseMapper.toRegionResponse(xml).srchList();
+        return commonResponseMapper.toCommonResponse(xml).srchList();
     }
 
     public List<CommonResponse.ScnItem> getMiddleRegion() {
@@ -42,7 +42,7 @@ public class RegionApiService {
 
     private List<CommonResponse.ScnItem> getMiddleRegionsForLargeCode(String largeCode, String largeName){
         String xml = commonApiCaller.callCommonApi("01", largeCode, null);
-        CommonResponse response = commonResponseMapper.toRegionResponse(xml);
+        CommonResponse response = commonResponseMapper.toCommonResponse(xml);
 
         return response.srchList().scnList()
                 .stream()

--- a/src/main/java/com/dodream/region/domain/Region.java
+++ b/src/main/java/com/dodream/region/domain/Region.java
@@ -25,7 +25,7 @@ public class Region extends BaseLongIdEntity {
     @Column(name = "region_name", nullable = false)
     private String regionName;
 
-    public static Region create(
+    public static Region of(
             String regionCode,
             String regionName
     ){

--- a/src/main/java/com/dodream/region/infrastructure/RegionInitializer.java
+++ b/src/main/java/com/dodream/region/infrastructure/RegionInitializer.java
@@ -21,12 +21,12 @@ public class RegionInitializer {
 
     @PostConstruct
     public void initRegionData() {
-        log.info("[initRegionData] - 지역 코드 초기화 시작");
-
         if(regionRepository.count() != 0) {
             // 이미 데이터 init된 경우라면 수행 x
             return;
         }
+
+        log.info("[initRegionData] - 지역 코드 초기화 시작");
 
         List<CommonResponse.ScnItem> regionList = regionApiService.getMiddleRegion();
 

--- a/src/main/java/com/dodream/region/infrastructure/RegionInitializer.java
+++ b/src/main/java/com/dodream/region/infrastructure/RegionInitializer.java
@@ -31,7 +31,7 @@ public class RegionInitializer {
         List<CommonResponse.ScnItem> regionList = regionApiService.getMiddleRegion();
 
         List<Region> regionJpaEntityList = regionList.stream()
-                .map(item -> Region.create(
+                .map(item -> Region.of(
                         item.rsltCode(),
                         item.rsltName()
                 ))

--- a/src/main/java/com/dodream/region/presentation/controller/RegionController.java
+++ b/src/main/java/com/dodream/region/presentation/controller/RegionController.java
@@ -29,18 +29,14 @@ public class RegionController implements RegionSwagger {
 
     @GetMapping("/name/{name}")
     public ResponseEntity<RestResponse<RegionResponseDto>> getRegionByName(
-            @PathVariable
-            @Parameter(name = "name", description = "지역명 (예시: 경기 안양시 만안구)", example = "서울 종로구")
-            @NotBlank(message = "지역명은 필수입니다") String name
+            @PathVariable String name
     ){
         return ResponseEntity.ok(new RestResponse<>(regionService.findByName(name)));
     }
 
     @GetMapping("/code/{code}")
     public ResponseEntity<RestResponse<RegionResponseDto>> getRegionByCode(
-            @PathVariable
-            @Parameter(name = "code", description = "지역 코드(5자리 정수(String))", example = "11110")
-            @Pattern(regexp = "^[0-9]{5}$", message = "지역 코드는 5자리 숫자여야 합니다") String code
+            @PathVariable String code
     ){
         return ResponseEntity.ok(new RestResponse<>(regionService.findByRegionCode(code)));
     }

--- a/src/main/java/com/dodream/region/presentation/controller/RegionController.java
+++ b/src/main/java/com/dodream/region/presentation/controller/RegionController.java
@@ -29,6 +29,8 @@ public class RegionController implements RegionSwagger {
 
     @GetMapping("/name/{name}")
     public ResponseEntity<RestResponse<RegionResponseDto>> getRegionByName(
+            @Parameter(name = "name", description = "지역명 (예시: 경기 안양시 만안구)", example = "서울 종로구")
+            @NotBlank(message = "지역명은 필수입니다")
             @PathVariable String name
     ){
         return ResponseEntity.ok(new RestResponse<>(regionService.findByName(name)));
@@ -36,6 +38,8 @@ public class RegionController implements RegionSwagger {
 
     @GetMapping("/code/{code}")
     public ResponseEntity<RestResponse<RegionResponseDto>> getRegionByCode(
+            @Parameter(name = "code", description = "지역 코드(5자리 정수(String))", example = "11110")
+            @Pattern(regexp = "^[0-9]{5}$", message = "지역 코드는 5자리 숫자여야 합니다")
             @PathVariable String code
     ){
         return ResponseEntity.ok(new RestResponse<>(regionService.findByRegionCode(code)));

--- a/src/main/java/com/dodream/region/presentation/swagger/RegionSwagger.java
+++ b/src/main/java/com/dodream/region/presentation/swagger/RegionSwagger.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -32,7 +31,6 @@ public interface RegionSwagger {
     )
     @ApiErrorCode(RegionErrorCode.class)
     ResponseEntity<RestResponse<RegionResponseDto>> getRegionByName(
-            @PathVariable
             @Parameter(name = "name", description = "지역명 (예시: 경기 안양시 만안구)", example = "서울 종로구")
             @NotBlank(message = "지역명은 필수입니다") String name
     );
@@ -44,7 +42,6 @@ public interface RegionSwagger {
     )
     @ApiErrorCode(RegionErrorCode.class)
     ResponseEntity<RestResponse<RegionResponseDto>> getRegionByCode(
-            @PathVariable
             @Parameter(name = "code", description = "지역 코드(5자리 정수(String))", example = "11110")
             @Pattern(regexp = "^[0-9]{5}$", message = "지역 코드는 5자리 숫자여야 합니다") String code
     );

--- a/src/test/java/com/dodream/ncs/NcsApiServiceTest.java
+++ b/src/test/java/com/dodream/ncs/NcsApiServiceTest.java
@@ -43,7 +43,7 @@ class NcsApiServiceTest {
         CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
 
         when(commonApiCaller.callCommonApi("05", null, null)).thenReturn(xml);
-        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+        when(commonResponseMapper.toCommonResponse(xml)).thenReturn(mockResponse);
 
         // when
         SrchList result = ncsApiService.getLargeNcsInfo();
@@ -66,7 +66,7 @@ class NcsApiServiceTest {
         CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
 
         when(commonApiCaller.callCommonApi("06", null, null)).thenReturn(xml);
-        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+        when(commonResponseMapper.toCommonResponse(xml)).thenReturn(mockResponse);
 
         // when
         SrchList result = ncsApiService.getMiddleNcsInfo();
@@ -89,7 +89,7 @@ class NcsApiServiceTest {
         CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
 
         when(commonApiCaller.callCommonApi("07", null, null)).thenReturn(xml);
-        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+        when(commonResponseMapper.toCommonResponse(xml)).thenReturn(mockResponse);
 
         // when
         SrchList result = ncsApiService.getSmallNcsInfo();
@@ -112,7 +112,7 @@ class NcsApiServiceTest {
         CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
 
         when(commonApiCaller.callCommonApi("08", null, null)).thenReturn(xml);
-        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+        when(commonResponseMapper.toCommonResponse(xml)).thenReturn(mockResponse);
 
         // when
         SrchList result = ncsApiService.getSmallestNcsInfo();

--- a/src/test/java/com/dodream/ncs/NcsApiServiceTest.java
+++ b/src/test/java/com/dodream/ncs/NcsApiServiceTest.java
@@ -1,0 +1,124 @@
+package com.dodream.ncs;
+
+import com.dodream.common.dto.response.CommonResponse;
+import com.dodream.common.dto.response.CommonResponse.ScnItem;
+import com.dodream.common.dto.response.CommonResponse.SrchList;
+import com.dodream.common.infrastructure.CommonApiCaller;
+import com.dodream.common.infrastructure.mapper.CommonResponseMapper;
+import com.dodream.ncs.application.NcsApiService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NcsApiServiceTest {
+
+    @Mock
+    private CommonApiCaller commonApiCaller;
+
+    @Mock
+    private CommonResponseMapper commonResponseMapper;
+
+    @InjectMocks
+    private NcsApiService ncsApiService;
+
+    @Test
+    @DisplayName("대분류 NCS 정보 조회 성공 테스트")
+    void getLargeNcsInfoTest() {
+        // given
+        String xml = "<mocked-xml/>";
+        List<ScnItem> itemList = List.of(
+                new ScnItem("01", "직무1", "Y"),
+                new ScnItem("02", "직무2", "Y")
+        );
+        SrchList srchList = new SrchList(itemList);
+        CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
+
+        when(commonApiCaller.callCommonApi("05", null, null)).thenReturn(xml);
+        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+
+        // when
+        SrchList result = ncsApiService.getLargeNcsInfo();
+
+        // then
+        assertEquals(2, result.scnList().size());
+        verify(commonApiCaller).callCommonApi("05", null, null);
+    }
+
+    @Test
+    @DisplayName("중분류 NCS 정보 조회 성공 테스트")
+    void getMiddleNcsInfoTest() {
+        // given
+        String xml = "<mocked-xml/>";
+        List<ScnItem> itemList = List.of(
+                new ScnItem("0101", "직무1", "Y"),
+                new ScnItem("0201", "직무2", "Y")
+        );
+        SrchList srchList = new SrchList(itemList);
+        CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
+
+        when(commonApiCaller.callCommonApi("06", null, null)).thenReturn(xml);
+        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+
+        // when
+        SrchList result = ncsApiService.getMiddleNcsInfo();
+
+        // then
+        assertEquals(2, result.scnList().size());
+        verify(commonApiCaller).callCommonApi("06", null, null);
+    }
+
+    @Test
+    @DisplayName("소분류 NCS 정보 조회 성공 테스트")
+    void getSmallNcsInfoTest() {
+        // given
+        String xml = "<mocked-xml/>";
+        List<ScnItem> itemList = List.of(
+                new ScnItem("010101", "직무1", "Y"),
+                new ScnItem("020101", "직무2", "Y")
+        );
+        SrchList srchList = new SrchList(itemList);
+        CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
+
+        when(commonApiCaller.callCommonApi("07", null, null)).thenReturn(xml);
+        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+
+        // when
+        SrchList result = ncsApiService.getSmallNcsInfo();
+
+        // then
+        assertEquals(2, result.scnList().size());
+        verify(commonApiCaller).callCommonApi("07", null, null);
+    }
+
+    @Test
+    @DisplayName("세분류 NCS 정보 조회 성공 테스트")
+    void getSmallestNcsInfoTest() {
+        // given
+        String xml = "<mocked-xml/>";
+        List<ScnItem> itemList = List.of(
+                new ScnItem("01010101", "직무1", "Y"),
+                new ScnItem("02010101", "직무2", "Y")
+        );
+        SrchList srchList = new SrchList(itemList);
+        CommonResponse mockResponse = new CommonResponse("직무", "2", srchList);
+
+        when(commonApiCaller.callCommonApi("08", null, null)).thenReturn(xml);
+        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(mockResponse);
+
+        // when
+        SrchList result = ncsApiService.getSmallestNcsInfo();
+
+        // then
+        assertEquals(2, result.scnList().size());
+        verify(commonApiCaller).callCommonApi("08", null, null);
+    }
+}

--- a/src/test/java/com/dodream/ncs/NcsServiceTest.java
+++ b/src/test/java/com/dodream/ncs/NcsServiceTest.java
@@ -1,0 +1,135 @@
+package com.dodream.ncs;
+
+import com.dodream.core.exception.DomainException;
+import com.dodream.ncs.application.NcsService;
+import com.dodream.ncs.domain.Ncs;
+import com.dodream.ncs.dto.response.NcsResponseDto;
+import com.dodream.ncs.repository.NcsRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class NcsServiceTest {
+
+    @Mock
+    private NcsRepository ncsRepository;
+
+    @InjectMocks
+    private NcsService ncsService;
+
+    private static final String TEST_NCS_CODE = "12";
+    private static final String TEST_NCS_NAME = "이용·숙박·여행·오락·스포츠";
+
+    @Nested
+    @DisplayName("[NcsServiceTest] - 전체 조회 테스트")
+    class getAllNcsTest{
+
+        @Test
+        @DisplayName("전체 조회 성공 테스트")
+        void getAllNcsTestSuccess(){
+            // given
+            Ncs ncs1 = mock(Ncs.class);
+            Ncs ncs2 = mock(Ncs.class);
+
+            when(ncs1.getNcsCode()).thenReturn(TEST_NCS_CODE);
+            when(ncs2.getNcsCode()).thenReturn(TEST_NCS_CODE);
+
+            when(ncs1.getNcsName()).thenReturn(TEST_NCS_NAME);
+            when(ncs2.getNcsName()).thenReturn(TEST_NCS_NAME);
+
+            List<Ncs> ncsList = List.of(ncs1, ncs2);
+
+            when(ncsRepository.findAll()).thenReturn(ncsList);
+
+            // when
+            List<NcsResponseDto> result = ncsService.getAllNcs();
+
+            // then
+            assertEquals(2, result.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("[NcsServiceTest] - 직무 이름으로 조회 테스트")
+    class getNcsByNameTest{
+
+        @Test
+        @DisplayName("직무 이름으로 조회 성공 테스트")
+        void getNcsByNameTestSuccess(){
+            // given
+            Ncs ncs1 = mock(Ncs.class);
+
+            when(ncs1.getNcsCode()).thenReturn(TEST_NCS_CODE);
+            when(ncs1.getNcsName()).thenReturn(TEST_NCS_NAME);
+
+            when(ncsRepository.findByNcsName(TEST_NCS_NAME)).thenReturn(Optional.of(ncs1));
+
+            // when
+            NcsResponseDto result = ncsService.getNcsByNcsName(TEST_NCS_NAME);
+
+            // then
+            assertEquals(result.ncsName(), TEST_NCS_NAME);
+            assertEquals(result.ncsCode(), TEST_NCS_CODE);
+        }
+
+        @Test
+        @DisplayName("직무 이름으로 조회 실패 테스트")
+        void getNcsByNameTestFail(){
+            // given
+            when(ncsRepository.findByNcsName(TEST_NCS_NAME)).thenReturn(Optional.empty());
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> ncsService.getNcsByNcsName(TEST_NCS_NAME))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessageContaining("NCS 데이터를 찾을 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("[NcsServiceTest] - 직무 코드로 조회 테스트")
+    class getNcsByCodeTest{
+
+        @Test
+        @DisplayName("직무 코드로 조회 성공")
+        void getNcsByCodeTestSuccess(){
+            // given
+            Ncs ncs1 = mock(Ncs.class);
+
+            when(ncs1.getNcsCode()).thenReturn(TEST_NCS_CODE);
+            when(ncs1.getNcsName()).thenReturn(TEST_NCS_NAME);
+
+            when(ncsRepository.findByNcsCode(TEST_NCS_CODE)).thenReturn(Optional.of(ncs1));
+
+            // when
+            NcsResponseDto result = ncsService.getNcsByNcsCode(TEST_NCS_CODE);
+
+            // then
+            assertEquals(result.ncsCode(), TEST_NCS_CODE);
+            assertEquals(result.ncsName(), TEST_NCS_NAME);
+        }
+
+        @Test
+        @DisplayName("직무 코드로 조회 실패 테스트")
+        void getNcsByCodeTestFail(){
+            // given
+            when(ncsRepository.findByNcsCode(TEST_NCS_CODE)).thenReturn(Optional.empty());
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> ncsService.getNcsByNcsCode(TEST_NCS_CODE))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessageContaining("NCS 데이터를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/com/dodream/region/RegionApiServiceTest.java
+++ b/src/test/java/com/dodream/region/RegionApiServiceTest.java
@@ -1,8 +1,9 @@
-package com.dodream.region.application;
+package com.dodream.region;
 
 import com.dodream.common.dto.response.CommonResponse;
 import com.dodream.common.infrastructure.CommonApiCaller;
 import com.dodream.common.infrastructure.mapper.CommonResponseMapper;
+import com.dodream.region.application.RegionApiService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/dodream/region/RegionApiServiceTest.java
+++ b/src/test/java/com/dodream/region/RegionApiServiceTest.java
@@ -41,7 +41,7 @@ public class RegionApiServiceTest {
         CommonResponse response = new CommonResponse("코드이름", "개수", srchList);
 
         when(commonApiCaller.callCommonApi("00", null, null)).thenReturn(xml);
-        when(commonResponseMapper.toRegionResponse(xml)).thenReturn(response);
+        when(commonResponseMapper.toCommonResponse(xml)).thenReturn(response);
 
         // when
         CommonResponse.SrchList result = regionApiService.getLargeRegionCode();
@@ -68,11 +68,11 @@ public class RegionApiServiceTest {
 
         when(commonApiCaller.callCommonApi("00", null, null))
                 .thenReturn(largeXml);
-        when(commonResponseMapper.toRegionResponse(largeXml)).thenReturn(largeResponse);
+        when(commonResponseMapper.toCommonResponse(largeXml)).thenReturn(largeResponse);
 
         when(commonApiCaller.callCommonApi("01", "11", null))
                 .thenReturn(middleXml);
-        when(commonResponseMapper.toRegionResponse(middleXml)).thenReturn(middleResponse);
+        when(commonResponseMapper.toCommonResponse(middleXml)).thenReturn(middleResponse);
 
         // when
         List<CommonResponse.ScnItem> result = regionApiService.getMiddleRegion();

--- a/src/test/java/com/dodream/region/RegionServiceTest.java
+++ b/src/test/java/com/dodream/region/RegionServiceTest.java
@@ -1,7 +1,9 @@
-package com.dodream.region.application;
+package com.dodream.region;
 
 import com.dodream.core.exception.DomainException;
+import com.dodream.region.application.RegionService;
 import com.dodream.region.domain.Region;
+import com.dodream.region.dto.response.RegionResponseDto;
 import com.dodream.region.repository.RegionRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 고용24 제공 API를 활용하여 NCS 직무 정보 및 코드 데이터를 DB에 저장했습니다
- 이 데이터는 최초 실행시 단 1번만 저장됩니다.
- DB에 저장된 NCS 관련 정보를 조회하는 컨트롤러를 구현했습니다.

## ✏️ 관련 이슈
#57 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - NCS(국가직무능력표준) 정보를 조회하는 REST API가 추가되었습니다. 전체 NCS 목록, 이름 또는 코드로 개별 NCS 정보를 조회할 수 있습니다.
    - NCS 데이터가 최초 실행 시 자동으로 초기화되어 저장됩니다.
    - NCS 관련 도메인, 서비스, DTO, 예외 처리, 저장소, 초기화 컴포넌트가 새롭게 도입되었습니다.

- **버그 수정**
    - 지역(Region) 관련 API의 입력값 검증 및 Swagger 문서화 어노테이션이 일부 수정되었습니다.

- **문서화**
    - NCS 및 지역 관련 API의 Swagger 문서가 개선되었습니다.

- **테스트**
    - NCS 서비스 및 API 서비스에 대한 단위 테스트가 추가되었습니다.
    - 일부 테스트 파일의 패키지 및 import가 정리되었습니다.

- **리팩터링**
    - Region 엔티티의 정적 팩토리 메서드명이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->