### PR TITLE
Feat(#83): 직업 탐색 관련 API를 만든다.

### DIFF
--- a/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
@@ -32,7 +32,8 @@ public class SecurityConfiguration {
         "/v1/member/auth/check-id/**",
         "/v1/member/auth/check-nickname/**",
         "/v1/member/auth/login",
-        "/v1/clova/**"
+        "/v1/clova/**",
+        "/v1/job/**"
     };
 
     @Bean

--- a/src/main/java/com/dodream/job/application/JobService.java
+++ b/src/main/java/com/dodream/job/application/JobService.java
@@ -6,6 +6,9 @@ import com.dodream.job.dto.response.JobResponseDto;
 import com.dodream.job.exception.JobErrorCode;
 import com.dodream.job.repository.JobRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,8 +27,9 @@ public class JobService {
         return JobResponseDto.from(job);
     }
 
-    public List<JobListDto> getAllJobs() {
-        List<Job> jobs = jobRepository.findAll();
+    public List<JobListDto> getAllJobs(int pageNumber) {
+        Pageable pageable = PageRequest.of(pageNumber, 9);
+        Page<Job> jobs = jobRepository.findAll(pageable);
 
         return jobs.stream()
                 .map(job -> JobListDto.from(job))

--- a/src/main/java/com/dodream/job/application/JobService.java
+++ b/src/main/java/com/dodream/job/application/JobService.java
@@ -28,6 +28,10 @@ public class JobService {
     }
 
     public List<JobListDto> getAllJobs(int pageNumber) {
+        if(pageNumber < 0) {
+            pageNumber = 0;
+        }
+
         Pageable pageable = PageRequest.of(pageNumber, 9);
         Page<Job> jobs = jobRepository.findAll(pageable);
 

--- a/src/main/java/com/dodream/job/application/JobService.java
+++ b/src/main/java/com/dodream/job/application/JobService.java
@@ -1,0 +1,34 @@
+package com.dodream.job.application;
+
+import com.dodream.job.domain.Job;
+import com.dodream.job.dto.response.JobListDto;
+import com.dodream.job.dto.response.JobResponseDto;
+import com.dodream.job.exception.JobErrorCode;
+import com.dodream.job.repository.JobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JobService {
+
+    private final JobRepository jobRepository;
+
+    public JobResponseDto getJobById(Long id) {
+        Job job = jobRepository.findById(id).orElseThrow(
+                JobErrorCode.CANNOT_GET_JOB_DATA::toException
+        );
+
+        return JobResponseDto.from(job);
+    }
+
+    public List<JobListDto> getAllJobs() {
+        List<Job> jobs = jobRepository.findAll();
+
+        return jobs.stream()
+                .map(job -> JobListDto.from(job))
+                .toList();
+    }
+}

--- a/src/main/java/com/dodream/job/controller/JobController.java
+++ b/src/main/java/com/dodream/job/controller/JobController.java
@@ -30,9 +30,11 @@ public class JobController implements JobSwagger {
 
     @Override
     @GetMapping("/list")
-    public ResponseEntity<RestResponse<List<JobListDto>>> getJobList() {
+    public ResponseEntity<RestResponse<List<JobListDto>>> getJobList(
+            @RequestParam int pageNum
+    ) {
         return ResponseEntity.ok(
-                new RestResponse<>(jobService.getAllJobs())
+                new RestResponse<>(jobService.getAllJobs(pageNum))
         );
     }
 }

--- a/src/main/java/com/dodream/job/controller/JobController.java
+++ b/src/main/java/com/dodream/job/controller/JobController.java
@@ -1,0 +1,38 @@
+package com.dodream.job.controller;
+
+import com.dodream.core.presentation.RestResponse;
+import com.dodream.job.application.JobService;
+import com.dodream.job.controller.swagger.JobSwagger;
+import com.dodream.job.dto.response.JobListDto;
+import com.dodream.job.dto.response.JobResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/job")
+@RequiredArgsConstructor
+public class JobController implements JobSwagger {
+
+    private final JobService jobService;
+
+    @Override
+    @GetMapping("/detail/{id}")
+    public ResponseEntity<RestResponse<JobResponseDto>> getJobDetail(
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(
+                new RestResponse<>(jobService.getJobById(id))
+        );
+    }
+
+    @Override
+    @GetMapping("/list")
+    public ResponseEntity<RestResponse<List<JobListDto>>> getJobList() {
+        return ResponseEntity.ok(
+                new RestResponse<>(jobService.getAllJobs())
+        );
+    }
+}

--- a/src/main/java/com/dodream/job/controller/swagger/JobSwagger.java
+++ b/src/main/java/com/dodream/job/controller/swagger/JobSwagger.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -30,5 +31,7 @@ public interface JobSwagger {
             description = "직업 탐색에서 사용하는 직업 카드 데이터를 반환합니다.",
             operationId = "/v1/job/list"
     )
-    ResponseEntity<RestResponse<List<JobListDto>>> getJobList();
+    ResponseEntity<RestResponse<List<JobListDto>>> getJobList(
+            @RequestParam int pageNum
+    );
 }

--- a/src/main/java/com/dodream/job/controller/swagger/JobSwagger.java
+++ b/src/main/java/com/dodream/job/controller/swagger/JobSwagger.java
@@ -1,0 +1,34 @@
+package com.dodream.job.controller.swagger;
+
+import com.dodream.core.config.swagger.ApiErrorCode;
+import com.dodream.core.presentation.RestResponse;
+import com.dodream.job.dto.response.JobListDto;
+import com.dodream.job.dto.response.JobResponseDto;
+import com.dodream.job.exception.JobErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(name = "Job-Search", description = "직업 탐색 관련 컨트롤러")
+public interface JobSwagger {
+
+    @Operation(
+            summary = "직업 상세정보 반환 컨트롤러",
+            description = "각 직업의 상세정보를 반환합니다.(직업 탐색 상세)",
+            operationId = "/v1/job/{id}"
+    )
+    @ApiErrorCode(JobErrorCode.class)
+    ResponseEntity<RestResponse<JobResponseDto>> getJobDetail(
+            @PathVariable Long id
+    );
+
+    @Operation(
+            summary = "직업 탐색 직업 반환",
+            description = "직업 탐색에서 사용하는 직업 카드 데이터를 반환합니다.",
+            operationId = "/v1/job/list"
+    )
+    ResponseEntity<RestResponse<List<JobListDto>>> getJobList();
+}

--- a/src/main/java/com/dodream/job/domain/Certification.java
+++ b/src/main/java/com/dodream/job/domain/Certification.java
@@ -23,6 +23,6 @@ public class Certification extends BaseLongIdEntity {
     private String certificationPreparationPeriod;
 
     @ManyToOne
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "job_id")
     private Job job;
 }

--- a/src/main/java/com/dodream/job/domain/Certification.java
+++ b/src/main/java/com/dodream/job/domain/Certification.java
@@ -1,0 +1,28 @@
+package com.dodream.job.domain;
+
+import com.dodream.core.infrastructure.jpa.entity.BaseLongIdEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Table(name = "certification")
+public class Certification extends BaseLongIdEntity {
+
+    @Column(nullable = false, name = "certification_name")
+    private String certificationName;
+
+    @Column(nullable = false, name = "certification_preparation_period")
+    private String certificationPreparationPeriod;
+
+    @ManyToOne
+    @JoinColumn(name = "id")
+    private Job job;
+}

--- a/src/main/java/com/dodream/job/domain/Job.java
+++ b/src/main/java/com/dodream/job/domain/Job.java
@@ -44,7 +44,7 @@ public class Job extends BaseLongIdEntity {
 
     @Column(nullable = false, name = "physical_activity_level")
     @Enumerated(EnumType.STRING)
-    private Level physicalActivityLevel;
+    private PhysicalActivity physicalActivityLevel;
 
     @Column(nullable = false, name = "emotional_labor_level")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dodream/job/domain/Job.java
+++ b/src/main/java/com/dodream/job/domain/Job.java
@@ -1,0 +1,54 @@
+package com.dodream.job.domain;
+
+import com.dodream.core.infrastructure.jpa.entity.BaseLongIdEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Table(name = "job")
+public class Job extends BaseLongIdEntity {
+
+    @Column(nullable = false, name = "job_name")
+    private String jobName;
+
+    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Certification> certifications = new ArrayList<>();
+
+    @Column(nullable = false, name = "requires_certification")
+    private boolean requiresCertification;
+
+    @Column(nullable = false, name = "work_time_slot")
+    private String workTimeSlot;
+
+    @Column(nullable = false, name = "salay_type")
+    private String salayType;
+
+    @Column(nullable = false, name = "salary_cost")
+    private int salaryCost;
+
+    @Column(nullable = false, name = "interpersonal_contact_level")
+    private Level interpersonalContactLevel;
+
+    @Column(nullable = false, name = "physical_activity_level")
+    private Level physicalActivityLevel;
+
+    @Column(nullable = false, name = "emotional_labor_level")
+    private Level emotionalLaborLevel;
+
+    @Column(name = "job_image_url")
+    private String jobImageUrl;
+
+    @Column(nullable = false, name = "ncs_name")
+    private String ncsName;
+}

--- a/src/main/java/com/dodream/job/domain/Job.java
+++ b/src/main/java/com/dodream/job/domain/Job.java
@@ -10,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter

--- a/src/main/java/com/dodream/job/domain/Job.java
+++ b/src/main/java/com/dodream/job/domain/Job.java
@@ -10,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -27,7 +28,8 @@ public class Job extends BaseLongIdEntity {
     private Require requiresCertification;
 
     @Column(nullable = false, name = "work_time_slot")
-    private String workTimeSlot;
+    @Enumerated(EnumType.STRING)
+    private WorkTime workTimeSlot;
 
     @Column(nullable = false, name = "salary_type")
     @Enumerated(EnumType.STRING)
@@ -56,4 +58,17 @@ public class Job extends BaseLongIdEntity {
 
     @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Certification> certifications = new ArrayList<>();
+
+
+    public List<String> getCertificationNames(List<Certification> certificationList) {
+        return certificationList.stream()
+                .map(Certification::getCertificationName)
+                .toList();
+    }
+
+    public List<String> getCertificationPeriods(List<Certification> certificationList) {
+        return certificationList.stream()
+                .map(Certification::getCertificationPreparationPeriod)
+                .toList();
+    }
 }

--- a/src/main/java/com/dodream/job/domain/Job.java
+++ b/src/main/java/com/dodream/job/domain/Job.java
@@ -22,28 +22,30 @@ public class Job extends BaseLongIdEntity {
     @Column(nullable = false, name = "job_name")
     private String jobName;
 
-    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
-    List<Certification> certifications = new ArrayList<>();
-
     @Column(nullable = false, name = "requires_certification")
-    private boolean requiresCertification;
+    @Enumerated(EnumType.STRING)
+    private Require requiresCertification;
 
     @Column(nullable = false, name = "work_time_slot")
     private String workTimeSlot;
 
-    @Column(nullable = false, name = "salay_type")
-    private String salayType;
+    @Column(nullable = false, name = "salary_type")
+    @Enumerated(EnumType.STRING)
+    private SalaryType salaryType;
 
     @Column(nullable = false, name = "salary_cost")
     private int salaryCost;
 
     @Column(nullable = false, name = "interpersonal_contact_level")
+    @Enumerated(EnumType.STRING)
     private Level interpersonalContactLevel;
 
     @Column(nullable = false, name = "physical_activity_level")
+    @Enumerated(EnumType.STRING)
     private Level physicalActivityLevel;
 
     @Column(nullable = false, name = "emotional_labor_level")
+    @Enumerated(EnumType.STRING)
     private Level emotionalLaborLevel;
 
     @Column(name = "job_image_url")
@@ -51,4 +53,7 @@ public class Job extends BaseLongIdEntity {
 
     @Column(nullable = false, name = "ncs_name")
     private String ncsName;
+
+    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Certification> certifications = new ArrayList<>();
 }

--- a/src/main/java/com/dodream/job/domain/Job.java
+++ b/src/main/java/com/dodream/job/domain/Job.java
@@ -10,7 +10,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Entity
 @Getter

--- a/src/main/java/com/dodream/job/domain/Level.java
+++ b/src/main/java/com/dodream/job/domain/Level.java
@@ -1,7 +1,14 @@
 package com.dodream.job.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum Level {
-    HIGH,
-    MEDIUM,
-    LOW
+    HIGH("높음"),
+    MEDIUM("중간"),
+    LOW("낮음");
+
+    private final String description;
 }

--- a/src/main/java/com/dodream/job/domain/Level.java
+++ b/src/main/java/com/dodream/job/domain/Level.java
@@ -1,0 +1,7 @@
+package com.dodream.job.domain;
+
+public enum Level {
+    HIGH,
+    MEDIUM,
+    LOW
+}

--- a/src/main/java/com/dodream/job/domain/PhysicalActivity.java
+++ b/src/main/java/com/dodream/job/domain/PhysicalActivity.java
@@ -1,0 +1,14 @@
+package com.dodream.job.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PhysicalActivity {
+    HIGH("움직임이 많은 활동"),
+    MEDIUM("가벼운 활동"),
+    LOW("정적인 활동");
+
+    private final String description;
+}

--- a/src/main/java/com/dodream/job/domain/Require.java
+++ b/src/main/java/com/dodream/job/domain/Require.java
@@ -1,0 +1,7 @@
+package com.dodream.job.domain;
+
+public enum Require {
+    NONE,
+    OPTIONAL,
+    REQUIRED
+}

--- a/src/main/java/com/dodream/job/domain/SalaryType.java
+++ b/src/main/java/com/dodream/job/domain/SalaryType.java
@@ -3,11 +3,12 @@ package com.dodream.job.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Getter
-public enum Require {
-    NONE("필요 없음"),
-    REQUIRED("필요함");
+@RequiredArgsConstructor
+public enum SalaryType {
+    MONTHLY("월급"),
+    DAILY("일급"),
+    PER_CASE("건당");
 
     private final String description;
 }

--- a/src/main/java/com/dodream/job/domain/WorkTime.java
+++ b/src/main/java/com/dodream/job/domain/WorkTime.java
@@ -1,0 +1,17 @@
+package com.dodream.job.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum WorkTime {
+    WEEKDAY_MORNING("평일 오전"),
+    WEEKDAY_AFTERNOON("평일 오후"),
+    WEEKDAY_NINE_TO_SIX("평일 9-18시"),
+    WEEKEND("주말 근무"),
+    EVENT("이벤트성"),
+    FLEXIBLE("탄력 근무");
+
+    private final String description;
+}

--- a/src/main/java/com/dodream/job/dto/response/JobListDto.java
+++ b/src/main/java/com/dodream/job/dto/response/JobListDto.java
@@ -1,0 +1,45 @@
+package com.dodream.job.dto.response;
+
+import com.dodream.job.domain.Job;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record JobListDto(
+
+        @Schema(name = "직업 DB 식별자", example = "1")
+        Long jobId,
+
+        @Schema(name = "직업 이름", example = "요양보호사")
+        String jobName,
+
+        @Schema(name = "직업 설명", example = "요양보호사는 ~")
+        String jobDescription,
+
+        @Schema(name = "자격증 필요 정보", example = "필요")
+        String requiredCertification,
+
+        @Schema(name = "근무 시간대", example = "평일 오전 9시- 18시")
+        String workTimeInfo,
+
+        @Schema(name = "신체활동 정보", example = "움직임이 많은 활동")
+        String physicalInfo,
+        
+        @Schema(name = "직업 이미지 url", example = "직업 이미지 url")
+        String imageUrl
+) {
+
+        public static JobListDto from(Job job){
+                return new JobListDto(
+                        job.getId(),
+                        job.getJobName(),
+                        // TODO: 직업 상세 추후 추가
+                        "직업 상세는 추후 추가",
+                        job.getRequiresCertification().getDescription(),
+                        job.getWorkTimeSlot().getDescription(),
+                        job.getPhysicalActivityLevel().getDescription(),
+                        // TODO: 직업 이미지 추가 후 추가
+                        "직업 이미지 url은 추후 추가"
+                );
+        }
+}

--- a/src/main/java/com/dodream/job/dto/response/JobResponseDto.java
+++ b/src/main/java/com/dodream/job/dto/response/JobResponseDto.java
@@ -26,7 +26,7 @@ public record JobResponseDto(
         String salaryCost,
 
         @Schema(name="강도")
-        Strong Strong
+        Strong strong
 ) {
 
     public record Strong(

--- a/src/main/java/com/dodream/job/dto/response/JobResponseDto.java
+++ b/src/main/java/com/dodream/job/dto/response/JobResponseDto.java
@@ -1,0 +1,59 @@
+package com.dodream.job.dto.response;
+
+import com.dodream.job.domain.Job;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record JobResponseDto(
+
+        @Schema(name="직업 이름", example = "요양보호사")
+        String jobName,
+
+        @Schema(name = "직업 소개", example = "요양보호사는 ~")
+        String jobDescription,
+
+        @Schema(name = "자격증", example = "요양보호사 자격증")
+        List<String> certification,
+
+        @Schema(name = "자격증 준비 기간", example = "약 1개월")
+        List<String> certificationPeriod,
+
+        @Schema(name = "급여 태그", example = "월급")
+        String salaryType,
+
+        @Schema(name = "급여 금액", example = "약 220만원")
+        String salaryCost,
+
+        @Schema(name="강도")
+        Strong Strong
+) {
+
+    public record Strong(
+
+            @Schema(name = "신체활동 정도", example = "움직임이 많은 활동")
+            String physical,
+
+            @Schema(name = "정신적 스트레스", example = "높음")
+            String stress,
+
+            @Schema(name = "대인관계 빈도", example = "높음")
+            String relationship
+    ) {}
+
+    public static JobResponseDto from(Job job){
+        return new JobResponseDto(
+                job.getJobName(),
+                "직업 상세는 추후 추가",
+                job.getCertificationNames(job.getCertifications()),
+                job.getCertificationPeriods(job.getCertifications()),
+                job.getSalaryType().getDescription(),
+                String.valueOf(job.getSalaryCost()) + "만원",
+                new Strong(
+                        job.getPhysicalActivityLevel().getDescription(),
+                        job.getEmotionalLaborLevel().getDescription(),
+                        job.getInterpersonalContactLevel().getDescription()
+                )
+        );
+    }
+}

--- a/src/main/java/com/dodream/job/exception/JobErrorCode.java
+++ b/src/main/java/com/dodream/job/exception/JobErrorCode.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum JobErrorCode implements BaseErrorCode<DomainException> {
 
     CANNOT_CONVERT_CLOVA_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "객체 변환에 실패했습니다."),
+    CANNOT_GET_JOB_DATA(HttpStatus.NOT_FOUND, "직업 데이터를 찾을 수 없습니다."),
     CLOVA_API_CALL_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Clova Chat Completion API 호출에 실패했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dodream/job/repository/CertificationRepository.java
+++ b/src/main/java/com/dodream/job/repository/CertificationRepository.java
@@ -1,0 +1,8 @@
+package com.dodream.job.repository;
+
+import com.dodream.job.domain.Certification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CertificationRepository extends JpaRepository<Certification, Long> {
+
+}

--- a/src/main/java/com/dodream/job/repository/JobRepository.java
+++ b/src/main/java/com/dodream/job/repository/JobRepository.java
@@ -3,7 +3,5 @@ package com.dodream.job.repository;
 import com.dodream.job.domain.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface JobRepository extends JpaRepository<Job, Long> {
 }

--- a/src/main/java/com/dodream/job/repository/JobRepository.java
+++ b/src/main/java/com/dodream/job/repository/JobRepository.java
@@ -1,0 +1,9 @@
+package com.dodream.job.repository;
+
+import com.dodream.job.domain.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,44 @@
+-- 직업 목록 init
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('요양보호사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '220', 'MONTHLY', 'HIGH', 'HIGH', 'HIGH', '요양지원');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('간호조무사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '230', 'MONTHLY', 'HIGH', 'MEDIUM', 'HIGH', '감염관리');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('보육교사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '220', 'MONTHLY', 'HIGH', 'HIGH', 'HIGH', '아이돌봄');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('사회복지사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'HIGH', 'MEDIUM', 'HIGH', '사회복지면담');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('직업상담사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'HIGH', 'LOW', 'MEDIUM', '직업상담');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('심리상담사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'HIGH', 'LOW', 'HIGH', '심리상담');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('급식 도우미', 'NONE', 'WEEKDAY_MORNING', '170', 'MONTHLY', 'MEDIUM', 'HIGH', 'MEDIUM', '음식조리');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('사무보조원', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '210', 'MONTHLY', 'LOW', 'LOW', 'LOW', '사무행정');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('회계사무원', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '240', 'MONTHLY', 'LOW', 'LOW', 'LOW', '회계·감사');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('수의테크니션', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '220', 'MONTHLY', 'LOW', 'LOW', 'LOW', '수의서비스');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('웨딩 헬퍼', 'NONE', 'EVENT', '20', 'DAILY', 'HIGH', 'HIGH', 'HIGH', '결혼서비스');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('미용사 (일반)', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'HIGH', 'HIGH', 'MEDIUM', '헤어미용');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('미용사 (피부)', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'HIGH', 'HIGH', 'HIGH', '피부미용');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('미용사 (네일)', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '230', 'MONTHLY', 'HIGH', 'MEDIUM', 'HIGH', '메이크업');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('미용사 (메이크업)', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'HIGH', 'MEDIUM', 'HIGH', '네일미용');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('반려동물미용사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '250', 'MONTHLY', 'MEDIUM', 'HIGH', 'LOW', '애완동물미용');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('레크리에이션 지도사', 'REQUIRED', 'EVENT', '10', 'PER_CASE', 'HIGH', 'HIGH', 'MEDIUM', '레크리에이션지도');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('바리스타', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '190', 'MONTHLY', 'MEDIUM', 'MEDIUM', 'LOW', '커피관리');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('공인중개사', 'REQUIRED', 'FLEXIBLE', '250', 'MONTHLY', 'HIGH', 'MEDIUM', 'HIGH', '부동산');
+INSERT INTO job (job_name, requires_certification, work_time_slot, salary_cost, salary_type, interpersonal_contact_level, physical_activity_level, emotional_labor_level, ncs_name) VALUES ('산후조리사', 'REQUIRED', 'WEEKDAY_NINE_TO_SIX', '230', 'MONTHLY', 'HIGH', 'MEDIUM', 'HIGH', '산후육아지원');
+
+-- 자격증
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('1', '요양보호사 자격증', '1개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('2', '간호조무사 자격증', '1년');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('3', '보육교사 3급', '6~12개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('4', '사회복지사 2급', '1~2년');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('5', '직업 상담사 2급', '6~12개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('6', '임상심리사 2급', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('8', 'ITQ정보기술자격증', '1~2개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('8', '컴퓨터활용능력2급', '1~2개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('9', '전산 회계 2급', '1~2개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('10', '동물 보건사 자격증', '1개월 내');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('12', '미용사(일반) 자격증', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('13', '피부관리사 자격증', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('13', '미용사(피부) 자격증', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('14', '미용사 (네일) 자격증', '4~5개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('15', '미용사 (메이크업)자격증', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('16', '애견미용사자격증', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('16', '반려견 스타일리스트 자격증', '3~6개월');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('17', '레크리에이션 지도사 자격증', '1개월 내');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('18', '바리스타 자격증', '1개월 내');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('19', '공인중개사', '6개월~1년');
+INSERT INTO certification (job_id, certification_name, certification_preparation_period) VALUES ('20', '산후조리사 자격증(민간)', '1~2개월');


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 직업 탐색에서 사용하는 데이터를 init한다
- 직업 탐색에서 사용하는 api를 만든다.

## ✏️ 관련 이슈
#83 

## 🎸 기타 사항 or 추가 코멘트
- initailize는 나중에합니다. 아직 db에 데이터 없어서 api는 배포시 작동 안합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 직업 목록 및 상세 정보를 조회할 수 있는 REST API가 추가되었습니다.
  - 직업 및 관련 자격증 정보를 위한 데이터베이스 구조와 엔티티가 도입되었습니다.
  - 직업 데이터와 자격증 데이터가 초기 데이터로 제공됩니다.

- **버그 수정**
  - 인증 없이 접근 가능한 경로에 직업 관련 엔드포인트가 추가되었습니다.

- **문서화**
  - 직업 관련 API에 대한 Swagger 문서가 추가되어 엔드포인트와 응답 구조를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->