### PR TITLE
Feat(#119): 훈련 과정 검색시 시작, 종료일을 설정 가능하게 한다.

### DIFF
--- a/src/main/java/com/dodream/training/application/BootcampService.java
+++ b/src/main/java/com/dodream/training/application/BootcampService.java
@@ -9,6 +9,8 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 @Log4j2
 public class BootcampService{
@@ -31,13 +33,13 @@ public class BootcampService{
     }
 
     public TrainingListApiResponse getList(
-            String pageNum, String regionName, String ncsName
+            String pageNum, String regionName, String jobName, LocalDate startDate, LocalDate endDate
     ) {
         String regionCode = trainingCodeResolver.resolveRegionCode(regionName);
-        String ncsCode = trainingCodeResolver.resolveNcsCode(ncsName);
+        String ncsCode = trainingCodeResolver.resolveNcsCode(jobName);
 
         String result = trainingApiExecuter.callListApi(
-                pageNum, regionCode, ncsCode
+                pageNum, regionCode, ncsCode, startDate, endDate
         );
 
         return listMapper.jsonToResponseDto(result);

--- a/src/main/java/com/dodream/training/application/DualTrainingService.java
+++ b/src/main/java/com/dodream/training/application/DualTrainingService.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 @Log4j2
 public class DualTrainingService {
@@ -33,13 +35,13 @@ public class DualTrainingService {
     }
 
     public TrainingListApiResponse getList(
-            String pageNum, String regionName, String ncsName
+            String pageNum, String regionName, String ncsName, LocalDate startDate, LocalDate endDate
     ) {
         String regionCode = trainingCodeResolver.resolveRegionCode(regionName);
         String ncsCode = trainingCodeResolver.resolveNcsCode(ncsName);
 
         String result = trainingApiExecuter.callListApi(
-                pageNum, regionCode, ncsCode
+                pageNum, regionCode, ncsCode, startDate, endDate
         );
 
         return listMapper.jsonToResponseDto(result);

--- a/src/main/java/com/dodream/training/controller/TrainingController.java
+++ b/src/main/java/com/dodream/training/controller/TrainingController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+
 @RestController
 @RequestMapping("/v1/training")
 @RequiredArgsConstructor
@@ -25,10 +27,12 @@ public class TrainingController implements TrainingSwagger {
     public ResponseEntity<RestResponse<TrainingListApiResponse>> getBootcampList(
         @RequestParam String pageNum,
         @RequestParam(required = false) String regionName,
-        @RequestParam(required = false) String ncsName
+        @RequestParam(required = false) String jobName,
+        @RequestParam(required = false) LocalDate startDate,
+        @RequestParam(required = false) LocalDate endDate
     ){
         return ResponseEntity.ok(new RestResponse<>(
-                bootcampService.getList(pageNum, regionName, ncsName))
+                bootcampService.getList(pageNum, regionName, jobName, startDate, endDate))
         );
     }
 
@@ -48,10 +52,12 @@ public class TrainingController implements TrainingSwagger {
     public ResponseEntity<RestResponse<TrainingListApiResponse>> getDualTrainingList(
             @RequestParam String pageNum,
             @RequestParam(required = false) String regionName,
-            @RequestParam(required = false) String ncsName
+            @RequestParam(required = false) String jobName,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate
     ) {
         return ResponseEntity.ok(new RestResponse<>(
-                dualTrainingService.getList(pageNum, regionName, ncsName)
+                dualTrainingService.getList(pageNum, regionName, jobName, startDate, endDate)
         ));
     }
 

--- a/src/main/java/com/dodream/training/controller/swagger/TrainingSwagger.java
+++ b/src/main/java/com/dodream/training/controller/swagger/TrainingSwagger.java
@@ -8,8 +8,11 @@ import com.dodream.training.exception.TrainingErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
 
 @Tag(name="Training", description = "국민내일배움카드 훈련과정 및 일병행학습 훈련과정 관련 API")
 public interface TrainingSwagger {
@@ -24,12 +27,24 @@ public interface TrainingSwagger {
             @RequestParam
             @Parameter(description = "검색 페이지 번호(1부터 시작하는 정수값)", example = "1")
             String pageNum,
+
             @RequestParam(required = false)
             @Parameter(description = "/v1/region/all을 요청시 나오는 지역 목록의 이름", example = "경기 안양시 만안구")
             String regionName,
+
             @RequestParam(required = false)
-            @Parameter(description = "/v1/ncs/all을 호출하여 나오는 직무 코드의 이름", example = "보건")
-            String ncsName
+            @Parameter(description = "/v1/job/list를 호출하여 나오는 직업의 이름", example = "요양보호사")
+            String jobName,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy/MM/dd")
+            @Parameter(description = "훈련 시작일 (yyyy/mm/dd)", example = "2025/05/07")
+            LocalDate startDate,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy/MM/dd")
+            @Parameter(description = "훈련 종료일 (yyyy/MM/dd)", example = "2025/08/07")
+            LocalDate endDate
     );
 
     @Operation(
@@ -69,12 +84,24 @@ public interface TrainingSwagger {
             @RequestParam
             @Parameter(description = "검색 페이지 번호(1부터 시작하는 정수값)", example = "1")
             String pageNum,
+
             @RequestParam(required = false)
             @Parameter(description = "/v1/region/all을 요청시 나오는 지역 목록의 이름", example = "경기 안양시 만안구")
             String regionName,
+
             @RequestParam(required = false)
-            @Parameter(description = "/v1/ncs/all을 호출하여 나오는 직무 코드의 이름", example = "보건")
-            String ncsName
+            @Parameter(description = "/v1/job/list를 호출하여 나오는 직업의 이름", example = "요양보호사")
+            String jobName,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy/MM/dd")
+            @Parameter(description = "훈련 시작일 (yyyy/MM/dd)", example = "2025/05/07")
+            LocalDate startDate,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy/MM/dd")
+            @Parameter(description = "훈련 종료일 (yyyy/MM/dd)", example = "2025/08/07")
+            LocalDate endDate
     );
 
     @Operation(

--- a/src/main/java/com/dodream/training/infrastructure/TrainingDatePolicy.java
+++ b/src/main/java/com/dodream/training/infrastructure/TrainingDatePolicy.java
@@ -16,11 +16,17 @@ public class TrainingDatePolicy {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    public String calculateStartDate() {
-        return LocalDate.now().minusMonths(monthDiff).format(FORMATTER);
+    public String calculateStartDate(LocalDate startDate) {
+        if(startDate == null || startDate.isBefore(LocalDate.now())) {
+            return LocalDate.now().format(FORMATTER);
+        }
+        return startDate.format(FORMATTER);
     }
 
-    public String calculateEndDate() {
-        return LocalDate.now().plusMonths(monthDiff).format(FORMATTER);
+    public String calculateEndDate(LocalDate endDate) {
+        if(endDate == null || endDate.isBefore(LocalDate.now())) {
+            return LocalDate.now().plusMonths(monthDiff).format(FORMATTER);
+        }
+        return endDate.format(FORMATTER);
     }
 }

--- a/src/main/java/com/dodream/training/util/TrainingCodeResolver.java
+++ b/src/main/java/com/dodream/training/util/TrainingCodeResolver.java
@@ -1,5 +1,8 @@
 package com.dodream.training.util;
 
+import com.dodream.job.domain.Job;
+import com.dodream.job.exception.JobErrorCode;
+import com.dodream.job.repository.JobRepository;
 import com.dodream.ncs.domain.Ncs;
 import com.dodream.ncs.exception.NcsErrorCode;
 import com.dodream.ncs.repository.NcsRepository;
@@ -14,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class TrainingCodeResolver {
 
     private final RegionRepository regionRepository;
+    private final JobRepository jobRepository;
     private final NcsRepository ncsRepository;
 
     public String resolveRegionCode(String regionName){
@@ -24,11 +28,14 @@ public class TrainingCodeResolver {
         return region.getRegionCode();
     }
 
-    public String resolveNcsCode(String ncsName) {
-        if (ncsName == null || ncsName.isEmpty()) return null;
+    public String resolveNcsCode(String jobName) {
+        if (jobName == null || jobName.isEmpty()) return null;
 
-        Ncs ncs = ncsRepository.findByNcsName(ncsName)
-                .orElseThrow(NcsErrorCode.NOT_FOUND_NCS::toException);
-        return ncs.getNcsCode();
+        Job job = jobRepository.findByJobName(jobName)
+                .orElseThrow(JobErrorCode.CANNOT_GET_JOB_DATA::toException);
+
+        return ncsRepository.findByNcsName(job.getNcsName())
+                .orElseThrow(NcsErrorCode.NOT_FOUND_NCS::toException)
+                .getNcsCode();
     }
 }

--- a/src/main/java/com/dodream/training/util/executer/BootcampApiExecuter.java
+++ b/src/main/java/com/dodream/training/util/executer/BootcampApiExecuter.java
@@ -5,6 +5,8 @@ import com.dodream.training.infrastructure.caller.TrainingApiCaller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.time.LocalDate;
+
 @RequiredArgsConstructor
 public class BootcampApiExecuter implements TrainingApiExecuter {
 
@@ -14,13 +16,13 @@ public class BootcampApiExecuter implements TrainingApiExecuter {
 
     @Override
     public String callListApi(
-            String pageNum, String regionCode, String ncsCode
+            String pageNum, String regionCode, String ncsCode, LocalDate startDate, LocalDate endDate
     ) {
-        String startDate = trainingDatePolicy.calculateStartDate();
-        String endDate = trainingDatePolicy.calculateEndDate();
+        String start = trainingDatePolicy.calculateStartDate(startDate);
+        String end = trainingDatePolicy.calculateEndDate(endDate);
 
         return trainingApiCaller.getListApi(
-                pageNum, regionCode, ncsCode, startDate, endDate
+                pageNum, regionCode, ncsCode, start, end
         );
     }
 

--- a/src/main/java/com/dodream/training/util/executer/DualTrainingApiExecuter.java
+++ b/src/main/java/com/dodream/training/util/executer/DualTrainingApiExecuter.java
@@ -5,6 +5,8 @@ import com.dodream.training.infrastructure.caller.TrainingApiCaller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.time.LocalDate;
+
 @RequiredArgsConstructor
 public class DualTrainingApiExecuter implements TrainingApiExecuter {
 
@@ -14,12 +16,12 @@ public class DualTrainingApiExecuter implements TrainingApiExecuter {
     private final TrainingDatePolicy trainingDatePolicy;
 
     @Override
-    public String callListApi(String pageNum, String regionCode, String ncsCode) {
-        String startDate = trainingDatePolicy.calculateStartDate();
-        String endDate = trainingDatePolicy.calculateEndDate();
+    public String callListApi(String pageNum, String regionCode, String ncsCode, LocalDate startDate, LocalDate endDate) {
+        String start = trainingDatePolicy.calculateStartDate(startDate);
+        String end = trainingDatePolicy.calculateEndDate(endDate);
 
         return trainingApiCaller.getListApi(
-                pageNum, regionCode, ncsCode, startDate, endDate
+                pageNum, regionCode, ncsCode, start, end
         );
     }
 

--- a/src/main/java/com/dodream/training/util/executer/TrainingApiExecuter.java
+++ b/src/main/java/com/dodream/training/util/executer/TrainingApiExecuter.java
@@ -1,8 +1,10 @@
 package com.dodream.training.util.executer;
 
+import java.time.LocalDate;
+
 public interface TrainingApiExecuter {
     String callListApi(
-            String pageNum, String regionCode, String ncsCode
+            String pageNum, String regionCode, String ncsCode, LocalDate startDate, LocalDate endDate
     );
 
     String callDetailApi(


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- yyyy/MM/dd 형식으로 시작 종료일을 입력할 수 있습니다.
- api 요청 파라미터를 늘렸습니다.

## ✏️ 관련 이슈
#119 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 부트캠프 및 이중훈련 과정 목록 조회 시 직업명(`jobName`)과 시작일/종료일(`startDate`, `endDate`)로 검색이 가능해졌습니다.

- **문서화**
    - API 문서에 새로운 검색 파라미터(`jobName`, `startDate`, `endDate`)가 추가되어 예시와 설명이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->