### PR TITLE
Refactor(#121): 사람인 API 요청 파라미터 조정 및 DTO 조정

### DIFF
--- a/src/main/java/com/dodream/recruit/application/RecruitService.java
+++ b/src/main/java/com/dodream/recruit/application/RecruitService.java
@@ -9,6 +9,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -19,11 +24,11 @@ public class RecruitService {
     private final RecruitCodeResolver recruitCodeResolver;
 
     public RecruitResponseListDto getRecruitList(
-            String keyWord, String locationName, int pageNum
+            String keyWord, String locationName, String startDate, String endDate, int pageNum
     ){
-        String result
-                = recruitApiCaller.recruitListApiListCaller(
-                        keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName), pageNum
+        String result = recruitApiCaller.recruitListApiListCaller(
+                        keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName),
+                        getDateTimeString(startDate), getDateTimeString(endDate), pageNum
                 );
 
         RecruitResponseListApiDto mappedResult = recruitMapper.recruitListMapper(result);
@@ -39,5 +44,20 @@ public class RecruitService {
         RecruitResponseListApiDto mappedResult = recruitMapper.recruitListMapper(result);
 
         return recruitMapper.toSimpleListDto(mappedResult);
+    }
+
+    private String getDateTimeString(String date){
+        if(date == null || date.isEmpty()){
+            return null;
+        }
+
+        DateTimeFormatter inputDateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+        LocalDate localDate = LocalDate.parse(date, inputDateFormatter);
+        LocalDateTime localDateTime = localDate.atStartOfDay();
+
+        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul"); // KST (UTC+9)
+        long unixTimestampSecondsSeoul = localDateTime.atZone(seoulZoneId).toEpochSecond();
+        return String.valueOf(unixTimestampSecondsSeoul);
     }
 }

--- a/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
+++ b/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
@@ -72,7 +72,7 @@ public record RecruitResponseListDto(
             @Schema(description = "게시일", example = "05/22(수)")
             String expirationDate,
 
-            @Schema(description = "마감일까지 남은 일수(채용시 마감인 경우 채용시 마감)", example = "6")
+            @Schema(description = "마감일까지 남은 일수(채용시 마감인 경우 채용시 마감)", example = "D-6")
             String deadline
     ){}
 

--- a/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
+++ b/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
@@ -1,9 +1,16 @@
 package com.dodream.recruit.dto.response;
 
+import com.dodream.recruit.exception.RecruitErrorCode;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Locale;
 
 public record RecruitResponseListDto(
         @JsonProperty("count")
@@ -35,16 +42,12 @@ public record RecruitResponseListDto(
             String title,
 
             @JsonProperty("locationName")
-            @Schema(description = "지역 이름", example = "경기 > 안양시 만안구")
+            @Schema(description = "지역 이름", example = "경기 안양시 만안구")
             String locationName,
 
             @JsonProperty("jobTypeName")
             @Schema(description = "근무형태", example = "정규직")
             String jobTypeName,
-
-            @JsonProperty("jobCode")
-            @Schema(description = "직무 이름", example = "노인복지, 간병인, 환자 안내")
-            String jobCode,
 
             @JsonProperty("experienceLevel")
             @Schema(description = "경력 정보", example = "경력 무관")
@@ -58,24 +61,25 @@ public record RecruitResponseListDto(
             @Schema(description = "접수 마감 정보", example = "접수 마감일")
             String closeType,
 
-            @JsonProperty("keyword")
-            @Schema(description = "직무 키워드", example = "노인 복지")
-            String keyword,
-
-            @JsonProperty("readCnt")
-            @Schema(description = "조회수", example = "25")
-            String readCnt,
-
             @JsonProperty("salary")
             @Schema(description = "연봉 값", example = "면접 후 결정")
             String salary,
 
             @JsonProperty("id")
             @Schema(description = "사람인 공고 ID", example = "50390519")
-            String id
+            String id,
+
+            @JsonProperty("expiration-date")
+            @Schema(description = "게시일", example = "05/22(수)")
+            String expirationDate,
+
+            @Schema(description = "마감일까지 남은 일수(채용시 마감인 경우 채용시 마감)", example = "6")
+            String deadline
     ){}
 
-    public static List<RecruitResponseListDto.Job> toResponseListDto(RecruitResponseListApiDto recruitResponseListApiDto){
+    public static List<RecruitResponseListDto.Job> toResponseListDto(
+            RecruitResponseListApiDto recruitResponseListApiDto
+    ){
         return recruitResponseListApiDto.jobs().job() == null
                 ? List.of()
                 : recruitResponseListApiDto.jobs().job().stream()
@@ -83,17 +87,67 @@ public record RecruitResponseListDto(
                         job.url(),
                         job.active(),
                         job.position() != null ? job.position().title() : null,
-                        job.position() != null && job.position().location() != null ? job.position().location().name().replace("&gt;", ">") : null,
+                        job.position() != null && job.position().location() != null
+                                ? job.position().location().name().replace("&gt;", "").replaceAll("\\s+", " ")
+                                : null,
                         job.position() != null && job.position().jobType() != null ? job.position().jobType().name() : null,
-                        job.position() != null && job.position().jobCode() != null ? job.position().jobCode().name() : null,
                         job.position() != null && job.position().experienceLevel() != null ? job.position().experienceLevel().name() : null,
                         job.position() != null && job.position().requiredEducationLevel() != null ? job.position().requiredEducationLevel().name() : null,
                         job.closeType() != null ? job.closeType().name() : null,
-                        job.keyword(),
-                        job.readCnt(),
                         job.salary() != null ? job.salary().name() : null,
-                        job.id()
+                        job.id(),
+                        getExpirationDate(job.expirationDate(), job.closeType().code()),
+                        getRemainingDate(job.expirationDate(), job.closeType().code())
                 ))
                 .toList();
+    }
+
+    private static String getRemainingDate(String date, String closeType){
+            if(closeType.equals("1")){
+                    ZonedDateTime expirationZdt = ZonedDateTime.parse(date, DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ssZ"));
+                    LocalDate expirationLocalDate = expirationZdt.toLocalDate();
+
+                    LocalDate todayKst = LocalDate.now(ZoneId.of("Asia/Seoul"));
+                    long daysBetween = ChronoUnit.DAYS.between(todayKst, expirationLocalDate);
+
+                    return "D-" + daysBetween;
+            }else if(closeType.equals("2")){
+                    return "채용시 마감";
+            }else if(closeType.equals("3")) {
+                    return "상시 채용";
+            }else if(closeType.equals("4")) {
+                    return "수시 채용";
+            }
+
+            return "일자 변환 오류";
+    }
+
+    private static String getExpirationDate(String date, String closeType){
+            if(closeType.equals("1")){
+                    return getFormattedDate(date);
+            }else if(closeType.equals("2")){
+                    return "채용시 마감";
+            }else if(closeType.equals("3")) {
+                    return "상시 채용";
+            }else if(closeType.equals("4")) {
+                    return "수시 채용";
+            }
+
+            return "일자 변환 오류";
+    }
+
+    private static String getFormattedDate(String date){
+            DateTimeFormatter INPUT_DATE_TIME_FORMATTER =
+                    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ssZ");
+
+            DateTimeFormatter OUTPUT_DATE_FORMATTER =
+                    DateTimeFormatter.ofPattern("MM/dd(E)", Locale.KOREAN);
+
+            String trimmedDateString = date.trim();
+
+            ZonedDateTime expirationZdt = ZonedDateTime.parse(trimmedDateString, INPUT_DATE_TIME_FORMATTER);
+            LocalDate localDate = expirationZdt.toLocalDate();
+
+            return localDate.format(OUTPUT_DATE_FORMATTER);
     }
 }

--- a/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
+++ b/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
@@ -1,6 +1,5 @@
 package com.dodream.recruit.dto.response;
 
-import com.dodream.recruit.exception.RecruitErrorCode;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
+++ b/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
@@ -109,6 +109,10 @@ public record RecruitResponseListDto(
                     LocalDate todayKst = LocalDate.now(ZoneId.of("Asia/Seoul"));
                     long daysBetween = ChronoUnit.DAYS.between(todayKst, expirationLocalDate);
 
+                    if(daysBetween < 0){
+                            return "마감됨";
+                    }
+
                     return "D-" + daysBetween;
             }else if(closeType.equals("2")){
                     return "채용시 마감";

--- a/src/main/java/com/dodream/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/com/dodream/recruit/exception/RecruitErrorCode.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum RecruitErrorCode implements BaseErrorCode<DomainException> {
     API_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "채용정보 API를 불러오는데 실패했습니다."),
     REGION_CODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "사람인 지역코드 정보를 불러오는데 실패했습니다."),
-    CANNOT_CONVERT_JSON(HttpStatus.INTERNAL_SERVER_ERROR, "Json 객체 변환에 실패했습니다.");
+    CANNOT_CONVERT_JSON(HttpStatus.INTERNAL_SERVER_ERROR, "Json 객체 변환에 실패했습니다."),
+    CONVERT_TIME_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "마감일 일정 변환에 실패했습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
@@ -2,12 +2,15 @@ package com.dodream.recruit.infrastructure;
 
 import com.dodream.core.infrastructure.cache.annotation.CustomCacheableWithLock;
 import com.dodream.recruit.exception.RecruitErrorCode;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RecruitApiCaller {
 
     private final RecruitFeignClient recruitFeignClient;
@@ -20,15 +23,17 @@ public class RecruitApiCaller {
 
     private final String FIELDS = "expiration-date";
 
-    @CustomCacheableWithLock(cacheName = "recruitList", ttl = 3)
+    @CustomCacheableWithLock(cacheName = "recruitList", ttl = 10)
     public String recruitListApiListCaller(
-            String keyWords, String locCd, int start
+            String keyWords, String locCd, String startDate, String endDate, int start
     ){
         try{
             return recruitFeignClient.getRecruitList(
                     accessKey,
                     keyWords,
                     locCd,
+                    startDate,
+                    endDate,
                     FIELDS,
                     start,
                     pageSize

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
@@ -18,7 +18,7 @@ public class RecruitApiCaller {
     @Value("${saramin.page-size}")
     private int pageSize;
 
-    private final String FIELDS = "count";
+    private final String FIELDS = "expiration-date";
 
     @CustomCacheableWithLock(cacheName = "recruitList", ttl = 3)
     public String recruitListApiListCaller(

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitFeignClient.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitFeignClient.java
@@ -9,8 +9,8 @@ public interface RecruitFeignClient {
     @GetMapping(value = "${saramin.endpoint}", headers = "Accept=application/json")
     String getRecruitList(
             @RequestParam(name = "access-key") String accessKey,
-            @RequestParam(name = "keywords") String keywords,
-            @RequestParam(name = "loc_cd") String locCd,
+            @RequestParam(name = "keywords", required = false) String keywords,
+            @RequestParam(name = "loc_cd", required = false) String locCd,
             @RequestParam(name = "fields") String fields,
             @RequestParam(name = "start") int start,
             @RequestParam(name = "count") int count

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitFeignClient.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitFeignClient.java
@@ -9,8 +9,8 @@ public interface RecruitFeignClient {
     @GetMapping(value = "${saramin.endpoint}", headers = "Accept=application/json")
     String getRecruitList(
             @RequestParam(name = "access-key") String accessKey,
-            @RequestParam(name = "keywords", required = false) String keywords,
-            @RequestParam(name = "loc_cd", required = false) String locCd,
+            @RequestParam(name = "keywords") String keywords,
+            @RequestParam(name = "loc_cd") String locCd,
             @RequestParam(name = "fields") String fields,
             @RequestParam(name = "start") int start,
             @RequestParam(name = "count") int count

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitFeignClient.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitFeignClient.java
@@ -11,6 +11,8 @@ public interface RecruitFeignClient {
             @RequestParam(name = "access-key") String accessKey,
             @RequestParam(name = "keywords") String keywords,
             @RequestParam(name = "loc_cd") String locCd,
+            @RequestParam(name = "published_min") String publishedMin, // TODO: datetime임
+            @RequestParam(name = "deadline") String deadline,           // TODO: 얘도 datetime
             @RequestParam(name = "fields") String fields,
             @RequestParam(name = "start") int start,
             @RequestParam(name = "count") int count

--- a/src/main/java/com/dodream/recruit/presentation/RecruitController.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitController.java
@@ -24,10 +24,12 @@ public class RecruitController implements RecruitSwagger{
     public ResponseEntity<RestResponse<RecruitResponseListDto>> getRecruitListController(
             @RequestParam int pageNum,
             @RequestParam(required = false) String keyWord,
-            @RequestParam(required = false) String locationName
+            @RequestParam(required = false) String locationName,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate
     ){
         return ResponseEntity.ok(new RestResponse<>(
-                recruitService.getRecruitList(keyWord, locationName, pageNum)
+                recruitService.getRecruitList(keyWord, locationName, startDate, endDate, pageNum)
         ));
     }
 

--- a/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
@@ -7,6 +7,7 @@ import com.dodream.recruit.exception.RecruitErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -30,10 +31,26 @@ public interface RecruitSwagger {
 
             @RequestParam
             @Parameter(
-                    description = "/v1/region/all을 호출해서 나오는 지역 이름(필수 입력 부탁드립니다.)",
+                    description = "/v1/region/all을 호출해서 나오는 지역 이름",
                     example = "경기 안양시 만안구"
             )
-            String locationName
+            String locationName,
+
+            @RequestParam
+            @DateTimeFormat(pattern = "yyyy/MM/dd")
+            @Parameter(
+                    description = "공고 시작일(yyyy/MM/dd)",
+                    example = "2025/05/09"
+            )
+            String startDate,
+
+            @RequestParam
+            @DateTimeFormat(pattern = "yyyy/MM/dd")
+            @Parameter(
+                    description = "공고 마감일(yyyy/MM/dd)",
+                    example = "2026/05/09"
+            )
+            String endDate
     );
 
     @Operation(

--- a/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
@@ -28,8 +28,11 @@ public interface RecruitSwagger {
             @Parameter(description = "검색을 위한 키워드", example = "요양보호사")
             String keyWord,
 
-            @RequestParam(required = false)
-            @Parameter(description = "/v1/region/all을 호출해서 나오는 지역 이름", example = "경기 안양시 만안구")
+            @RequestParam
+            @Parameter(
+                    description = "/v1/region/all을 호출해서 나오는 지역 이름(필수 입력 부탁드립니다.)",
+                    example = "경기 안양시 만안구"
+            )
             String locationName
     );
 

--- a/src/main/java/com/dodream/recruit/util/RecruitCodeResolver.java
+++ b/src/main/java/com/dodream/recruit/util/RecruitCodeResolver.java
@@ -1,6 +1,7 @@
 package com.dodream.recruit.util;
 
 import com.dodream.recruit.exception.RecruitErrorCode;
+import com.dodream.region.domain.Region;
 import com.dodream.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,7 @@ public class RecruitCodeResolver {
 
     public String resolveRecruitLocationName(String locName){
         return regionRepository.findByRegionName(locName)
-                .orElseThrow(RecruitErrorCode.REGION_CODE_ERROR::toException)
-                .getSaraminRegionCode();
+                .map(Region::getSaraminRegionCode)
+                .orElse(null);
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사람인 API의 요청 파라미터를 추가했습니다.(공고 게시일, 공고 마감일)
- 필요 데이터만 가져올 수 있도록 dto를 정리 했습니다.

## ✏️ 관련 이슈
#121 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 채용 목록 조회 시 시작일과 종료일을 지정하여 기간별 검색이 가능해졌습니다.
  - 채용 공고 응답에 마감일(예: MM/dd(요일)) 및 남은 기간(D-일수, 상시/수시 등) 정보가 추가되었습니다.

- **버그 수정**
  - 지역명 미존재 시 예외 대신 null 반환으로 동작이 개선되었습니다.

- **문서화**
  - API 문서에 날짜 필터(startDate, endDate)와 지역명 필수 입력이 반영되었습니다.

- **기타**
  - 마감일 변환 실패 시의 에러 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->