### PR TITLE
Fix(#127): 온보딩 결과에 이미지 url을 함께 보내준다

### DIFF
--- a/src/main/java/com/dodream/job/application/JobRecommendService.java
+++ b/src/main/java/com/dodream/job/application/JobRecommendService.java
@@ -30,6 +30,10 @@ public class JobRecommendService {
     private final JobDescriptionResolver jobDescriptionResolver;
 
     public JobRecommendationResponse recommendJob(CustomUserDetails customUserDetails, OnboardingAnswerSet answerSet) {
+        if(customUserDetails == null) {
+            throw JobErrorCode.CANNOT_FIND_USER_DATA.toException();
+        }
+
         String rawResponse = callClovaApi(customUserDetails.getUsername(), answerSet);
 
         JobRecommendationResponse rawRecommendation = parseRecommendationResponse(rawResponse);

--- a/src/main/java/com/dodream/job/application/JobRecommendService.java
+++ b/src/main/java/com/dodream/job/application/JobRecommendService.java
@@ -67,7 +67,10 @@ public class JobRecommendService {
 
     private JobRecommendationResponse.RecommendedJob enrichJobWithDescription(JobRecommendationResponse.RecommendedJob job) {
         String jobSum = jobDescriptionResolver.resolveJobSummary(job.jobTitle());
-        return new JobRecommendationResponse.RecommendedJob(job.jobTitle(), jobSum, job.reasons());
+        String imageUrl = jobRepository.findByJobName(job.jobTitle())
+                .orElseThrow(JobErrorCode.CANNOT_GET_JOB_DATA::toException)
+                .getJobImageUrl();
+        return new JobRecommendationResponse.RecommendedJob(job.jobTitle(), jobSum, imageUrl, job.reasons());
     }
 
     private JobRecommendationResponse parseRecommendationResponse(String rawResponse) {

--- a/src/main/java/com/dodream/job/dto/response/JobRecommendationResponse.java
+++ b/src/main/java/com/dodream/job/dto/response/JobRecommendationResponse.java
@@ -8,6 +8,7 @@ public record JobRecommendationResponse(
     public record RecommendedJob(
             String jobTitle,
             String jobDescription,
+            String imageUrl,
             Reasons reasons
     ) {}
 

--- a/src/main/java/com/dodream/job/exception/JobErrorCode.java
+++ b/src/main/java/com/dodream/job/exception/JobErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum JobErrorCode implements BaseErrorCode<DomainException> {
     CANNOT_CONVERT_JOB_OBJECT(HttpStatus.INTERNAL_SERVER_ERROR, "직무정보 객체로의 변환에 실패했습니다."),
+    CANNOT_FIND_USER_DATA(HttpStatus.NOT_FOUND, "온보딩을 진행한 유저 정보를 찾을 수 없습니다."),
     CANNOT_GET_CLOVA_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "Clova Studio 응답을 받지 못했습니다."),
     CANNOT_CONVERT_CLOVA_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "객체 변환에 실패했습니다."),
     CANNOT_GET_JOB_DATA(HttpStatus.NOT_FOUND, "직업 데이터를 찾을 수 없습니다."),


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 온보딩 결과를 볼때 직업 이미지를 볼 수 있게 imageUrl을 반환하게 한다.

## ✏️ 관련 이슈
#127 

## 🎸 기타 사항 or 추가 코멘트
