### PR TITLE
Feat(#133): 홈화면 - 채용정보 API를 만든다

### DIFF
--- a/src/main/java/com/dodream/job/repository/JobRepository.java
+++ b/src/main/java/com/dodream/job/repository/JobRepository.java
@@ -4,6 +4,7 @@ import com.dodream.job.domain.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JobRepository extends JpaRepository<Job, Long> {
@@ -21,4 +22,17 @@ public interface JobRepository extends JpaRepository<Job, Long> {
         ) AS top_job ON j.id = top_job.job_id
     """, nativeQuery = true)
     Optional<Job> findMostPopularJob();
+
+    @Query(value = """
+        SELECT j.*
+        FROM job j
+        JOIN (
+            SELECT job_id
+            FROM todo_group
+            GROUP BY job_id
+            ORDER BY COUNT(*) DESC
+            LIMIT 3
+        ) AS top_job ON j.id = top_job.job_id
+    """, nativeQuery = true)
+    List<Job> findTop3PopularJob();
 }

--- a/src/main/java/com/dodream/job/repository/JobRepository.java
+++ b/src/main/java/com/dodream/job/repository/JobRepository.java
@@ -2,9 +2,23 @@ package com.dodream.job.repository;
 
 import com.dodream.job.domain.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface JobRepository extends JpaRepository<Job, Long> {
     Optional<Job> findByJobName(String jobName);
+
+    @Query(value = """
+        SELECT j.*
+        FROM job j
+        JOIN (
+            SELECT job_id
+            FROM todo_group
+            GROUP BY job_id
+            ORDER BY COUNT(*) DESC
+            LIMIT 1
+        ) AS top_job ON j.id = top_job.job_id
+    """, nativeQuery = true)
+    Optional<Job> findMostPopularJob();
 }

--- a/src/main/java/com/dodream/recruit/application/RecruitService.java
+++ b/src/main/java/com/dodream/recruit/application/RecruitService.java
@@ -1,6 +1,9 @@
 package com.dodream.recruit.application;
 
 import com.dodream.core.infrastructure.security.CustomUserDetails;
+import com.dodream.job.domain.Job;
+import com.dodream.job.exception.JobErrorCode;
+import com.dodream.job.repository.JobRepository;
 import com.dodream.member.domain.Member;
 import com.dodream.member.exception.MemberErrorCode;
 import com.dodream.member.repository.MemberRepository;
@@ -9,7 +12,9 @@ import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import com.dodream.recruit.infrastructure.RecruitApiCaller;
 import com.dodream.recruit.infrastructure.mapper.RecruitMapper;
 import com.dodream.recruit.util.RecruitCodeResolver;
-import jakarta.transaction.Transactional;
+import com.dodream.todo.domain.TodoGroup;
+import com.dodream.todo.exception.TodoGroupErrorCode;
+import com.dodream.todo.repository.TodoGroupRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -28,11 +33,17 @@ public class RecruitService {
     private final RecruitMapper recruitMapper;
     private final RecruitCodeResolver recruitCodeResolver;
     private final MemberRepository memberRepository;
+    private final TodoGroupRepository todoGroupRepository;
+    private final JobRepository jobRepository;
 
     public RecruitResponseListDto getRecruitList(
             String keyWord, String locationName,
             String startDate, String endDate, int pageNum
     ){
+        if(keyWord == null){
+            keyWord = getTopJobNameInTodo();
+        }
+
         String result = recruitApiCaller.recruitListApiListCaller(
                     keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName),
                     getDateTimeString(startDate), getDateTimeString(endDate), pageNum
@@ -47,6 +58,9 @@ public class RecruitService {
             CustomUserDetails customUserDetails, String keyWord, String locationName,
             String startDate, String endDate, int pageNum
     ){
+        if(keyWord == null){
+            keyWord = getTopJobNameInMemberTodoGroup(customUserDetails);
+        }
         String result = recruitApiCaller.recruitListApiListCaller(
                 keyWord,
                 getRegionCodeByToken(customUserDetails),
@@ -94,5 +108,24 @@ public class RecruitService {
         } else{
             return member.getRegion().getSaraminRegionCode();
         }
+    }
+
+    private String getTopJobNameInMemberTodoGroup(CustomUserDetails customUserDetails){
+        Member member = memberRepository.findById(customUserDetails.getId())
+                .orElseThrow(MemberErrorCode.MEMBER_NOT_FOUND::toException);
+
+        TodoGroup todoGroup = todoGroupRepository.findTopByMemberOrderByTotalViewDesc(member)
+                .orElseThrow(TodoGroupErrorCode.TODO_GROUP_NOT_FOUND::toException);
+
+        Job job = todoGroup.getJob();
+
+        return job.getJobName();
+    }
+
+    private String getTopJobNameInTodo(){
+        Job job = jobRepository.findMostPopularJob()
+                .orElseThrow(JobErrorCode.CANNOT_GET_JOB_DATA::toException);
+
+        return job.getJobName();
     }
 }

--- a/src/main/java/com/dodream/recruit/application/RecruitService.java
+++ b/src/main/java/com/dodream/recruit/application/RecruitService.java
@@ -1,11 +1,15 @@
 package com.dodream.recruit.application;
 
 import com.dodream.core.infrastructure.security.CustomUserDetails;
+import com.dodream.member.domain.Member;
+import com.dodream.member.exception.MemberErrorCode;
+import com.dodream.member.repository.MemberRepository;
 import com.dodream.recruit.dto.response.RecruitResponseListApiDto;
 import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import com.dodream.recruit.infrastructure.RecruitApiCaller;
 import com.dodream.recruit.infrastructure.mapper.RecruitMapper;
 import com.dodream.recruit.util.RecruitCodeResolver;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -23,27 +27,33 @@ public class RecruitService {
     private final RecruitApiCaller recruitApiCaller;
     private final RecruitMapper recruitMapper;
     private final RecruitCodeResolver recruitCodeResolver;
+    private final MemberRepository memberRepository;
 
     public RecruitResponseListDto getRecruitList(
+            String keyWord, String locationName,
+            String startDate, String endDate, int pageNum
+    ){
+        String result = recruitApiCaller.recruitListApiListCaller(
+                    keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName),
+                    getDateTimeString(startDate), getDateTimeString(endDate), pageNum
+        );
+
+        RecruitResponseListApiDto mappedResult = recruitMapper.recruitListMapper(result);
+
+        return recruitMapper.toSimpleListDto(mappedResult);
+    }
+
+    public RecruitResponseListDto getRecruitListByToken(
             CustomUserDetails customUserDetails, String keyWord, String locationName,
             String startDate, String endDate, int pageNum
     ){
-        String result = null;
-        if(customUserDetails != null){
-            String locCode = customUserDetails.member().getRegion().getRegionCode();
-            result = recruitApiCaller.recruitListApiListCaller(
-                    keyWord,
-                    locCode,
-                    getDateTimeString(startDate),
-                    getDateTimeString(endDate),
-                    pageNum
-            );
-        }else{
-            result = recruitApiCaller.recruitListApiListCaller(
-                    keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName),
-                    getDateTimeString(startDate), getDateTimeString(endDate), pageNum
-            );
-        }
+        String result = recruitApiCaller.recruitListApiListCaller(
+                keyWord,
+                getRegionCodeByToken(customUserDetails),
+                getDateTimeString(startDate),
+                getDateTimeString(endDate),
+                pageNum
+        );
 
         RecruitResponseListApiDto mappedResult = recruitMapper.recruitListMapper(result);
 
@@ -73,5 +83,16 @@ public class RecruitService {
         ZoneId seoulZoneId = ZoneId.of("Asia/Seoul"); // KST (UTC+9)
         long unixTimestampSecondsSeoul = localDateTime.atZone(seoulZoneId).toEpochSecond();
         return String.valueOf(unixTimestampSecondsSeoul);
+    }
+
+    private String getRegionCodeByToken(CustomUserDetails customUserDetails) {
+        Member member = memberRepository.findById(customUserDetails.getId())
+                .orElseThrow(MemberErrorCode.MEMBER_NOT_FOUND::toException);
+
+        if(member.getRegion() == null) {
+            return null;
+        } else{
+            return member.getRegion().getSaraminRegionCode();
+        }
     }
 }

--- a/src/main/java/com/dodream/recruit/application/RecruitService.java
+++ b/src/main/java/com/dodream/recruit/application/RecruitService.java
@@ -1,5 +1,6 @@
 package com.dodream.recruit.application;
 
+import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.recruit.dto.response.RecruitResponseListApiDto;
 import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import com.dodream.recruit.infrastructure.RecruitApiCaller;
@@ -24,12 +25,25 @@ public class RecruitService {
     private final RecruitCodeResolver recruitCodeResolver;
 
     public RecruitResponseListDto getRecruitList(
-            String keyWord, String locationName, String startDate, String endDate, int pageNum
+            CustomUserDetails customUserDetails, String keyWord, String locationName,
+            String startDate, String endDate, int pageNum
     ){
-        String result = recruitApiCaller.recruitListApiListCaller(
-                        keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName),
-                        getDateTimeString(startDate), getDateTimeString(endDate), pageNum
-                );
+        String result = null;
+        if(customUserDetails != null){
+            String locCode = customUserDetails.member().getRegion().getRegionCode();
+            result = recruitApiCaller.recruitListApiListCaller(
+                    keyWord,
+                    locCode,
+                    getDateTimeString(startDate),
+                    getDateTimeString(endDate),
+                    pageNum
+            );
+        }else{
+            result = recruitApiCaller.recruitListApiListCaller(
+                    keyWord, recruitCodeResolver.resolveRecruitLocationName(locationName),
+                    getDateTimeString(startDate), getDateTimeString(endDate), pageNum
+            );
+        }
 
         RecruitResponseListApiDto mappedResult = recruitMapper.recruitListMapper(result);
 

--- a/src/main/java/com/dodream/recruit/dto/response/PopularRecruitResponse.java
+++ b/src/main/java/com/dodream/recruit/dto/response/PopularRecruitResponse.java
@@ -1,0 +1,15 @@
+package com.dodream.recruit.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PopularRecruitResponse(
+
+        @JsonProperty("job-name")
+        @Schema(description = "인기 직업 이름", example = "요양 보호사")
+        String jobName,
+
+        @JsonProperty("count")
+        @Schema(description = "현재 공고 건수", example = "23")
+        int count
+) {}

--- a/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
+++ b/src/main/java/com/dodream/recruit/dto/response/RecruitResponseListDto.java
@@ -80,8 +80,13 @@ public record RecruitResponseListDto(
             @Schema(description = "마감일", example = "05/22(수)")
             String expirationDate,
 
+            @JsonProperty("deadline")
             @Schema(description = "마감일까지 남은 일수(채용시 마감인 경우 채용시 마감)", example = "D-6")
-            String deadline
+            String deadline,
+
+            @JsonProperty("count")
+            @Schema(description = "조회수(N명이 관심을 보였어요)", example = "5")
+            String count
     ){}
 
     public static List<RecruitResponseListDto.Job> toResponseListDto(
@@ -106,7 +111,8 @@ public record RecruitResponseListDto(
                         job.id(),
                         job.expirationDate(),
                         getExpirationDate(job.expirationDate(), job.closeType().code()),
-                        getRemainingDate(job.expirationDate(), job.closeType().code())
+                        getRemainingDate(job.expirationDate(), job.closeType().code()),
+                        job.readCnt()
                 ))
                 .toList();
     }

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
@@ -21,7 +21,7 @@ public class RecruitApiCaller {
     @Value("${saramin.page-size}")
     private int pageSize;
 
-    private final String FIELDS = "expiration-date";
+    private final String FIELDS = "expiration-date+count";
 
     @CustomCacheableWithLock(cacheName = "recruitList", ttl = 15)
     public String recruitListApiListCaller(

--- a/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
+++ b/src/main/java/com/dodream/recruit/infrastructure/RecruitApiCaller.java
@@ -23,7 +23,7 @@ public class RecruitApiCaller {
 
     private final String FIELDS = "expiration-date+count";
 
-    @CustomCacheableWithLock(cacheName = "recruitList", ttl = 15)
+    @CustomCacheableWithLock(cacheName = "recruitList", ttl = 120)
     public String recruitListApiListCaller(
             String keyWords, String locCd, String startDate, String endDate, int start
     ){

--- a/src/main/java/com/dodream/recruit/presentation/RecruitController.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitController.java
@@ -1,10 +1,12 @@
 package com.dodream.recruit.presentation;
 
+import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.recruit.application.RecruitService;
 import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,6 +24,7 @@ public class RecruitController implements RecruitSwagger{
     @Override
     @GetMapping("/list")
     public ResponseEntity<RestResponse<RecruitResponseListDto>> getRecruitListController(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam int pageNum,
             @RequestParam(required = false) String keyWord,
             @RequestParam(required = false) String locationName,
@@ -29,7 +32,7 @@ public class RecruitController implements RecruitSwagger{
             @RequestParam(required = false) String endDate
     ){
         return ResponseEntity.ok(new RestResponse<>(
-                recruitService.getRecruitList(keyWord, locationName, startDate, endDate, pageNum)
+                recruitService.getRecruitList(customUserDetails, keyWord, locationName, startDate, endDate, pageNum)
         ));
     }
 

--- a/src/main/java/com/dodream/recruit/presentation/RecruitController.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitController.java
@@ -31,9 +31,20 @@ public class RecruitController implements RecruitSwagger{
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate
     ){
-        return ResponseEntity.ok(new RestResponse<>(
-                recruitService.getRecruitList(customUserDetails, keyWord, locationName, startDate, endDate, pageNum)
-        ));
+
+        if(customUserDetails != null){
+            return ResponseEntity.ok(new RestResponse<>(
+                    recruitService.getRecruitListByToken(
+                            customUserDetails, keyWord, locationName, startDate, endDate, pageNum
+                    )
+            ));
+        }else {
+            return ResponseEntity.ok(new RestResponse<>(
+                    recruitService.getRecruitList(
+                            keyWord, locationName, startDate, endDate, pageNum
+                    )
+            ));
+        }
     }
 
     @Override

--- a/src/main/java/com/dodream/recruit/presentation/RecruitController.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitController.java
@@ -3,6 +3,7 @@ package com.dodream.recruit.presentation;
 import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.recruit.application.RecruitService;
+import com.dodream.recruit.dto.response.PopularRecruitResponse;
 import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -53,5 +54,21 @@ public class RecruitController implements RecruitSwagger{
             @RequestParam String id
     ) {
         return ResponseEntity.ok(new RestResponse<>(recruitService.getRecruitDetail(id)));
+    }
+
+    @Override
+    @GetMapping("/popular")
+    public ResponseEntity<RestResponse<List<PopularRecruitResponse>>> getPopularRecruitDetailController(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        if(customUserDetails == null){
+            return ResponseEntity.ok(new RestResponse<>(
+                    recruitService.getPopularJobListByAllMember()
+            ));
+        }else{
+            return ResponseEntity.ok(new RestResponse<>(
+                    recruitService.getPopularJobListByTodoGroup(customUserDetails)
+            ));
+        }
     }
 }

--- a/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
@@ -1,6 +1,7 @@
 package com.dodream.recruit.presentation;
 
 import com.dodream.core.config.swagger.ApiErrorCode;
+import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import com.dodream.recruit.exception.RecruitErrorCode;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Recruit", description = "사람인 채용정보 관련 API")
@@ -21,6 +23,9 @@ public interface RecruitSwagger {
     )
     @ApiErrorCode(RecruitErrorCode.class)
     ResponseEntity<RestResponse<RecruitResponseListDto>> getRecruitListController(
+            @AuthenticationPrincipal
+            CustomUserDetails customUserDetails,
+
             @RequestParam
             @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
             int pageNum,

--- a/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
+++ b/src/main/java/com/dodream/recruit/presentation/RecruitSwagger.java
@@ -3,6 +3,7 @@ package com.dodream.recruit.presentation;
 import com.dodream.core.config.swagger.ApiErrorCode;
 import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.recruit.dto.response.PopularRecruitResponse;
 import com.dodream.recruit.dto.response.RecruitResponseListDto;
 import com.dodream.recruit.exception.RecruitErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "Recruit", description = "사람인 채용정보 관련 API")
 public interface RecruitSwagger {
@@ -68,5 +71,16 @@ public interface RecruitSwagger {
             @RequestParam
             @Parameter(description = "채용공고 검색시 나오는 id", example = "50611581")
             String id
+    );
+
+    @Operation(
+            summary = "인기 직업 공고 건수 반환 API",
+            description = "현재 가장 인기있는 직업의 공고 건수를 반환합니다. (홈화면 - 구인 현황(오른쪽 상단))",
+            operationId = "/v1/recruit/popular"
+    )
+    @ApiErrorCode(RecruitErrorCode.class)
+    ResponseEntity<RestResponse<List<PopularRecruitResponse>>> getPopularRecruitDetailController(
+            @AuthenticationPrincipal
+            CustomUserDetails customUserDetails
     );
 }

--- a/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
@@ -5,7 +5,6 @@ import com.dodream.todo.domain.TodoGroup;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
 
@@ -15,5 +14,5 @@ public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
 
     Optional<TodoGroup> findFirstByMemberOrderByIdAsc(Member member);
 
-
+    Optional<TodoGroup> findTopByMemberOrderByTotalViewDesc(Member member);
 }

--- a/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
@@ -15,4 +15,6 @@ public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
     Optional<TodoGroup> findFirstByMemberOrderByIdAsc(Member member);
 
     Optional<TodoGroup> findTopByMemberOrderByTotalViewDesc(Member member);
+
+    List<TodoGroup> findTop3ByMemberOrderByTotalViewDesc(Member member);
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- /v1/recruit/popular로 인기 직업 상위 3개 공고 건수 구할 수 있도록 만들었음
- 토큰을 유무에 따라 채용정보 API가 동작되도록 변환

## ✏️ 관련 이슈
#133 

## 🎸 기타 사항 or 추가 코멘트
- 사용 위치는 피그마 코멘트에~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인기 채용 직무 목록을 조회할 수 있는 엔드포인트가 추가되었습니다.
    - 사용자의 인증 여부에 따라 맞춤형 인기 직무 및 채용 리스트를 제공합니다.
    - 채용 공고 리스트와 상세 조회 시 직무별 조회수(관심 인원 수)가 표시됩니다.

- **개선 사항**
    - 채용 리스트 조회 시, 키워드가 없으면 전체 또는 사용자 기반 인기 직무가 자동 적용됩니다.
    - 인기 직무가 부족할 경우 랜덤 직무로 보완되어 최소 3개가 제공됩니다.
    - 채용 리스트 API 응답 속도를 높이기 위해 캐시 유지 시간이 늘어났습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->