### PR TITLE
Feat(#143): 직업 탐색 반환시 동적 필터 적용하여 반환

### DIFF
--- a/src/main/java/com/dodream/job/application/JobService.java
+++ b/src/main/java/com/dodream/job/application/JobService.java
@@ -5,10 +5,12 @@ import com.dodream.job.dto.response.JobListDto;
 import com.dodream.job.dto.response.JobResponseDto;
 import com.dodream.job.exception.JobErrorCode;
 import com.dodream.job.repository.JobRepository;
+import com.dodream.job.repository.JobSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,13 +29,14 @@ public class JobService {
         return JobResponseDto.from(job);
     }
 
-    public Page<JobListDto> getAllJobs(int pageNumber) {
+    public Page<JobListDto> getAllJobs(int pageNumber, String require, String workTime, String physical) {
         if(pageNumber < 0) {
             pageNumber = 0;
         }
 
         Pageable pageable = PageRequest.of(pageNumber, 9);
-        Page<Job> jobs = jobRepository.findAll(pageable);
+        Specification<Job> spec = JobSpecification.matchesFilter(require, workTime, physical);
+        Page<Job> jobs = jobRepository.findAll(spec, pageable);
 
         return jobs.map(JobListDto::from);
     }

--- a/src/main/java/com/dodream/job/controller/JobController.java
+++ b/src/main/java/com/dodream/job/controller/JobController.java
@@ -38,10 +38,20 @@ public class JobController implements JobSwagger {
     @Override
     @GetMapping("/list")
     public ResponseEntity<RestResponse<Page<JobListDto>>> getJobList(
-            @RequestParam int pageNum
+            @RequestParam
+            int pageNum,
+
+            @RequestParam(required = false)
+            String require,
+
+            @RequestParam(required = false)
+            String workTime,
+
+            @RequestParam(required = false)
+            String physical
     ) {
         return ResponseEntity.ok(
-                new RestResponse<>(jobService.getAllJobs(pageNum))
+                new RestResponse<>(jobService.getAllJobs(pageNum, require, workTime, physical))
         );
     }
 

--- a/src/main/java/com/dodream/job/controller/swagger/JobSwagger.java
+++ b/src/main/java/com/dodream/job/controller/swagger/JobSwagger.java
@@ -9,6 +9,7 @@ import com.dodream.job.dto.response.JobListDto;
 import com.dodream.job.dto.response.JobResponseDto;
 import com.dodream.job.exception.JobErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +40,20 @@ public interface JobSwagger {
     )
     @ApiErrorCode(JobErrorCode.class)
     ResponseEntity<RestResponse<Page<JobListDto>>> getJobList(
-            @RequestParam int pageNum
+            @RequestParam
+            int pageNum,
+
+            @RequestParam(required = false)
+            @Parameter(description = "자격증 필요 여부", example = "필요함")
+            String require,
+
+            @RequestParam(required = false)
+            @Parameter(description = "근무시간대", example = "평일 9시-18시")
+            String workTime,
+
+            @RequestParam(required = false)
+            @Parameter(description = "신체활동 정도", example = "정적인 활동")
+            String physical
     );
 
     @Operation(

--- a/src/main/java/com/dodream/job/repository/JobRepository.java
+++ b/src/main/java/com/dodream/job/repository/JobRepository.java
@@ -2,12 +2,13 @@ package com.dodream.job.repository;
 
 import com.dodream.job.domain.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface JobRepository extends JpaRepository<Job, Long> {
+public interface JobRepository extends JpaRepository<Job, Long>, JpaSpecificationExecutor<Job> {
     Optional<Job> findByJobName(String jobName);
 
     @Query(value = """

--- a/src/main/java/com/dodream/job/repository/JobSpecification.java
+++ b/src/main/java/com/dodream/job/repository/JobSpecification.java
@@ -34,9 +34,6 @@ public class JobSpecification {
                         .findFirst()
                         .orElse(null);
 
-                System.out.println("physical = " + physical);
-                System.out.println("매핑된 physicalEnum = " + physicalEnum);
-
                 if (physicalEnum != null) {
                     predicates.add(cb.equal(root.get("physicalActivityLevel"), physicalEnum));
                 }

--- a/src/main/java/com/dodream/job/repository/JobSpecification.java
+++ b/src/main/java/com/dodream/job/repository/JobSpecification.java
@@ -1,0 +1,58 @@
+package com.dodream.job.repository;
+
+import com.dodream.job.domain.Job;
+import com.dodream.job.domain.PhysicalActivity;
+import com.dodream.job.domain.Require;
+import com.dodream.job.domain.WorkTime;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class JobSpecification {
+
+    public static Specification<Job> matchesFilter(String require, String workTime, String physical){
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if(require != null && !require.isBlank()){
+                Require requireEnum = Arrays.stream(Require.values())
+                        .filter(r -> r.getDescription().equals(require))
+                        .findFirst()
+                        .orElse(null);
+
+                if(requireEnum != null){
+                    predicates.add(cb.equal(root.get("requiresCertification"), requireEnum));
+                }
+            }
+
+            if(physical != null && !physical.isBlank()){
+                PhysicalActivity physicalEnum  = Arrays.stream(PhysicalActivity.values())
+                        .filter(e -> e.getDescription().equals(physical))
+                        .findFirst()
+                        .orElse(null);
+
+                System.out.println("physical = " + physical);
+                System.out.println("매핑된 physicalEnum = " + physicalEnum);
+
+                if (physicalEnum != null) {
+                    predicates.add(cb.equal(root.get("physicalActivityLevel"), physicalEnum));
+                }
+            }
+
+            if(workTime != null && !workTime.isBlank()){
+                WorkTime workTimeEnum = Arrays.stream(WorkTime.values())
+                        .filter(w -> w.getDescription().equals(workTime))
+                        .findFirst().orElse(null);
+
+                if(workTimeEnum != null){
+                    predicates.add(cb.equal(root.get("workTimeSlot"), workTimeEnum));
+                }
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- Specification 적용하여 동적 필터 후 페이지네이션 적용되도록 변경
- 변경 API -> /v1/job/list

## ✏️ 관련 이슈
#143 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 일자리 목록 조회 시 자격증 필요 여부, 근무 시간대, 신체활동 정도로 필터링할 수 있는 옵션이 추가되었습니다.
- **문서화**
	- API 문서에 새로운 필터링 파라미터(require, workTime, physical)에 대한 설명과 예시가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->