### PR TITLE
Feat(#131) : 홈화면 타유저 투두 목록을 조회하는 api 구현한다.

### DIFF
--- a/src/main/java/com/dodream/todo/application/TodoMemberService.java
+++ b/src/main/java/com/dodream/todo/application/TodoMemberService.java
@@ -8,6 +8,7 @@ import com.dodream.job.repository.JobRepository;
 import com.dodream.job.repository.JobTodoRepository;
 import com.dodream.member.application.MemberAuthService;
 import com.dodream.member.domain.Member;
+import com.dodream.member.exception.MemberErrorCode;
 import com.dodream.todo.domain.Todo;
 import com.dodream.todo.domain.TodoGroup;
 import com.dodream.todo.domain.TodoImage;
@@ -70,6 +71,10 @@ public class TodoMemberService {
 
         Job job = jobRepository.findById(jobId)
             .orElseThrow(JobErrorCode.CANNOT_GET_JOB_DATA::toException);
+
+        if (todoGroupRepository.existsByMemberAndJob(member, job)){
+            throw TodoGroupErrorCode.JOB_EXISTS.toException();
+        }
 
         List<JobTodo> todoList = jobTodoRepository.findAllByJob(job);
 

--- a/src/main/java/com/dodream/todo/application/TodoService.java
+++ b/src/main/java/com/dodream/todo/application/TodoService.java
@@ -1,0 +1,61 @@
+package com.dodream.todo.application;
+
+import com.dodream.job.repository.JobRepository;
+import com.dodream.job.repository.JobTodoRepository;
+import com.dodream.member.application.MemberAuthService;
+import com.dodream.member.domain.Member;
+import com.dodream.todo.domain.Todo;
+import com.dodream.todo.domain.TodoGroup;
+import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.repository.TodoGroupRepository;
+import com.dodream.todo.repository.TodoRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TodoService {
+
+    private final MemberAuthService memberAuthService;
+    private final JobTodoRepository jobTodoRepository;
+    private final JobRepository jobRepository;
+    private final TodoRepository todoRepository;
+    private final TodoGroupRepository todoGroupRepository;
+
+
+    @Transactional(readOnly = true)
+    public List<GetOthersTodoGroupResponseDto> getOneTodoGroupAtHome() {
+
+        Member member = memberAuthService.getCurrentMember();
+
+        Optional<TodoGroup> todoGroup = todoGroupRepository.findFirstByMemberOrderByIdAsc(member);
+
+        if (todoGroup.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Pageable limit3 = PageRequest.of(0, 3);
+        List<TodoGroup> todoGroups = todoGroupRepository.findTop3ByJobAndNotMember(
+            todoGroup.get().getJob(), member, limit3);
+
+        Pageable top2 = PageRequest.of(0, 2);
+        List<GetOthersTodoGroupResponseDto> result = todoGroups.stream()
+            .map(group -> {
+                List<Todo> todos = todoRepository.findTop2ByTodoGroup(group, top2);
+                Long todoCount = todoRepository.countByTodoGroup(group);
+                return GetOthersTodoGroupResponseDto.of(group, todos, todoCount);
+            })
+            .toList();
+
+        return result;
+
+    }
+
+
+}

--- a/src/main/java/com/dodream/todo/application/TodoService.java
+++ b/src/main/java/com/dodream/todo/application/TodoService.java
@@ -23,8 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class TodoService {
 
     private final MemberAuthService memberAuthService;
-    private final JobTodoRepository jobTodoRepository;
-    private final JobRepository jobRepository;
     private final TodoRepository todoRepository;
     private final TodoGroupRepository todoGroupRepository;
 
@@ -45,17 +43,13 @@ public class TodoService {
             todoGroup.get().getJob(), member, limit3);
 
         Pageable top2 = PageRequest.of(0, 2);
-        List<GetOthersTodoGroupResponseDto> result = todoGroups.stream()
+        return todoGroups.stream()
             .map(group -> {
                 List<Todo> todos = todoRepository.findTop2ByTodoGroup(group, top2);
                 Long todoCount = todoRepository.countByTodoGroup(group);
                 return GetOthersTodoGroupResponseDto.of(group, todos, todoCount);
             })
             .toList();
-
-        return result;
-
     }
-
 
 }

--- a/src/main/java/com/dodream/todo/dto/response/GetOthersTodoGroupResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOthersTodoGroupResponseDto.java
@@ -1,0 +1,47 @@
+package com.dodream.todo.dto.response;
+
+import com.dodream.todo.domain.Todo;
+import com.dodream.todo.domain.TodoGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+
+@Builder
+public record GetOthersTodoGroupResponseDto(
+    @Schema(description = "투두 그룹 id", example = "12")
+    Long todoGroupId,
+    @Schema(description = "멤버 닉네임", example = "두둠칫")
+    String memberNickname,
+    @Schema(description = "거주지", example = "대전 광역시 서구")
+    String regionName,
+    @Schema(description = "투두 경과 일자(X일)", example = "38")
+    Long daysAgo,
+    @Schema(description = "직업 이름", example = "요양보호사")
+    String jobName,
+    @Schema(description = "투두 개수", example = "12")
+    Long todoCount,
+    @Schema(description = "투두 리스트")
+    List<GetOthersTodoResponseDto> todos
+
+) {
+
+    public static GetOthersTodoGroupResponseDto of(TodoGroup todoGroup, List<Todo> todos,
+        Long todoCount) {
+        return GetOthersTodoGroupResponseDto.builder()
+            .todoGroupId(todoGroup.getId())
+            .memberNickname(todoGroup.getMember().getNickName())
+            .regionName(todoGroup.getMember().getRegion().getRegionName())
+            .daysAgo(
+                ChronoUnit.DAYS.between(todoGroup.getCreatedAt().toLocalDate(), LocalDate.now())
+                    + 1)
+            .jobName(todoGroup.getJob().getJobName())
+            .todoCount(todoCount)
+            .todos(todos.stream()
+                .map(GetOthersTodoResponseDto::from)
+                .collect(Collectors.toList()))
+            .build();
+    }
+}

--- a/src/main/java/com/dodream/todo/dto/response/GetOthersTodoResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOthersTodoResponseDto.java
@@ -1,0 +1,23 @@
+package com.dodream.todo.dto.response;
+
+import com.dodream.todo.domain.Todo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetOthersTodoResponseDto(
+
+    @Schema(description = "투두 id", example = "5")
+    Long todoId,
+
+    @Schema(description = "투두 제목", example = "“급식 도우미 근무 조건” 키워드로 업무 시간대, 복장, 식단 보조 등 기본 정보 확인하기")
+    String title,
+
+    @Schema(description = "완료 여부", example = "false")
+    Boolean completed
+
+) {
+
+    public static GetOthersTodoResponseDto from(Todo todo) {
+        return new GetOthersTodoResponseDto(todo.getId(), todo.getTitle(), todo.getCompleted());
+    }
+
+}

--- a/src/main/java/com/dodream/todo/exception/TodoGroupErrorCode.java
+++ b/src/main/java/com/dodream/todo/exception/TodoGroupErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum TodoGroupErrorCode implements BaseErrorCode<DomainException> {
 
-    TODO_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO GROUP 데이터를 찾을 수 없습니다.");
+    TODO_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO GROUP 데이터를 찾을 수 없습니다."),
+    JOB_EXISTS(HttpStatus.BAD_REQUEST, "이미 담은 직업입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
+++ b/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
@@ -1,0 +1,30 @@
+package com.dodream.todo.presentation.controller;
+
+import com.dodream.core.presentation.RestResponse;
+import com.dodream.todo.application.TodoService;
+import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.presentation.swagger.TodoSwagger;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/todo")
+@RequiredArgsConstructor
+@Validated
+public class TodoController implements TodoSwagger {
+
+    private final TodoService todoService;
+
+    @Override
+    @GetMapping(value = "")
+    public ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupAtHome() {
+        return ResponseEntity.ok(
+            new RestResponse<>(todoService.getOneTodoGroupAtHome()));
+    }
+
+}

--- a/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
+++ b/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
@@ -21,7 +21,7 @@ public class TodoController implements TodoSwagger {
     private final TodoService todoService;
 
     @Override
-    @GetMapping(value = "")
+    @GetMapping(value = "/other")
     public ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupAtHome() {
         return ResponseEntity.ok(
             new RestResponse<>(todoService.getOneTodoGroupAtHome()));

--- a/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
+++ b/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
@@ -1,0 +1,24 @@
+package com.dodream.todo.presentation.swagger;
+
+import com.dodream.core.config.swagger.ApiErrorCode;
+import com.dodream.core.presentation.RestResponse;
+import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.exception.TodoErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Todo - 홈화면", description = "홈화면 - 투두 리스트 관련 API")
+public interface TodoSwagger {
+
+    @Operation(
+        summary = "홈화면 - 홈화면 타유저 투두 리스트 목록 조회 API",
+        description = "홈화면에서  타유저 투두 리스트 목록 조회 API",
+        operationId = "/v1/todo/other"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupAtHome();
+
+
+}

--- a/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
@@ -1,10 +1,14 @@
 package com.dodream.todo.repository;
 
+import com.dodream.job.domain.Job;
 import com.dodream.member.domain.Member;
 import com.dodream.todo.domain.TodoGroup;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
 
@@ -15,6 +19,14 @@ public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
     Optional<TodoGroup> findFirstByMemberOrderByIdAsc(Member member);
 
     Optional<TodoGroup> findTopByMemberOrderByTotalViewDesc(Member member);
+
+    boolean existsByMemberAndJob(Member member, Job job);
+
+    @Query("SELECT tg FROM TodoGroup tg " +
+           "WHERE tg.member <> :currentMember " +
+           "AND tg.job = :job " +
+           "AND tg.deleted = false")
+    List<TodoGroup> findTop3ByJobAndNotMember(@Param("job") Job job, @Param("currentMember") Member currentMember, Pageable pageable);
 
     List<TodoGroup> findTop3ByMemberOrderByTotalViewDesc(Member member);
 }

--- a/src/main/java/com/dodream/todo/repository/TodoRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoRepository.java
@@ -2,11 +2,23 @@ package com.dodream.todo.repository;
 
 import com.dodream.member.domain.Member;
 import com.dodream.todo.domain.Todo;
+import com.dodream.todo.domain.TodoGroup;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     Optional<Todo> findByIdAndMemberAndDeletedIsFalse(Long todoId, Member member);
+
+    @Query("SELECT t FROM Todo t WHERE t.todoGroup = :group AND t.deleted = false ORDER BY t.createdAt DESC")
+    List<Todo> findTop2ByTodoGroup(@Param("group") TodoGroup group, Pageable pageable);
+
+    @Query("SELECT COUNT(t) FROM Todo t WHERE t.todoGroup = :group AND t.deleted = false")
+    Long countByTodoGroup(@Param("group") TodoGroup group);
+
 
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 홈화면 타유저 투두 목록을 조회하는 api 구현
- 직업 중복 담기 예외처리

## ✏️ 관련 이슈
#131 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 홈 화면에서 다른 사용자의 투두 그룹 및 일부 투두 항목을 조회할 수 있는 API가 추가되었습니다.
    - 나의 투두 그룹에 이미 담은 직업을 중복 추가할 수 없도록 방지하는 검증이 도입되었습니다.

- **버그 수정**
    - 동일한 직업에 대해 투두 그룹이 중복 생성되는 문제를 방지합니다.

- **문서화**
    - 새로운 홈 화면 투두 조회 API에 대한 Swagger 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->