### PR TITLE
Feat(#158) : 타유저 투두 리스트 조회 api 구현한다.

### DIFF
--- a/src/main/java/com/dodream/todo/application/TodoService.java
+++ b/src/main/java/com/dodream/todo/application/TodoService.java
@@ -1,18 +1,31 @@
 package com.dodream.todo.application;
 
+import com.dodream.job.domain.Job;
+import com.dodream.job.domain.TodoCategory;
+import com.dodream.job.exception.JobErrorCode;
 import com.dodream.job.repository.JobRepository;
-import com.dodream.job.repository.JobTodoRepository;
 import com.dodream.member.application.MemberAuthService;
 import com.dodream.member.domain.Member;
 import com.dodream.todo.domain.Todo;
 import com.dodream.todo.domain.TodoGroup;
+import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
+import com.dodream.todo.dto.response.GetOneTodoResponseDto;
 import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.dto.response.GetOthersTodoSimpleResponseDto;
+import com.dodream.todo.dto.response.GetTodoGroupByCategoryResponseDto;
+import com.dodream.todo.exception.TodoGroupErrorCode;
 import com.dodream.todo.repository.TodoGroupRepository;
 import com.dodream.todo.repository.TodoRepository;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,6 +38,7 @@ public class TodoService {
     private final MemberAuthService memberAuthService;
     private final TodoRepository todoRepository;
     private final TodoGroupRepository todoGroupRepository;
+    private final JobRepository jobRepository;
 
 
     @Transactional(readOnly = true)
@@ -52,4 +66,75 @@ public class TodoService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<GetOthersTodoSimpleResponseDto> getOthersTodoSimple(Long jobId) {
+
+        Member member = memberAuthService.getCurrentMember();
+
+        Job job = jobRepository.findById(jobId)
+            .orElseThrow(JobErrorCode.CANNOT_GET_JOB_DATA::toException);
+
+        List<TodoGroup> todoGroups = todoGroupRepository.findTop5ByJobAndMemberNot(job, member);
+
+        return todoGroups.stream()
+            .map(group -> {
+                Long todoCount = todoRepository.countByTodoGroup(group);
+                return GetOthersTodoSimpleResponseDto.of(group, todoCount);
+            })
+            .collect(Collectors.toList());
+
+    }
+
+
+    // 특정 직업에 대한 타 유저 투두 리스트 조회( 전체 )
+    @Transactional(readOnly = true)
+    public Page<GetOthersTodoGroupResponseDto> getOthersTodoByJob(Long jobId, int page) {
+
+        Member member = memberAuthService.getCurrentMember();
+
+        Job job = jobRepository.findById(jobId)
+            .orElseThrow(JobErrorCode.CANNOT_GET_JOB_DATA::toException);
+
+        Pageable pageable = PageRequest.of(page, 10);
+        Page<TodoGroup> todoGroups = todoGroupRepository.findTop10ByJobAndNotMember(
+            job, member, pageable);
+
+        Pageable top3 = PageRequest.of(0, 3);
+        List<GetOthersTodoGroupResponseDto> result = todoGroups.stream()
+            .map(group -> {
+                List<Todo> todos = todoRepository.findTop3ByTodoGroup(group, top3);
+                Long todoCount = todoRepository.countByTodoGroup(group);
+                return GetOthersTodoGroupResponseDto.of(group, todos, todoCount);
+            })
+            .toList();
+
+        return new PageImpl<>(result, pageable, todoGroups.getTotalElements());
+
+    }
+
+    // 타유저 - 세부 조회
+    @Transactional(readOnly = true)
+    public GetOneTodoGroupResponseDto getOneOthersTodoGroup(Long TodoGroupId) {
+
+        Member member = memberAuthService.getCurrentMember();
+
+        TodoGroup todoGroup = todoGroupRepository.findByIdAndMemberNot(TodoGroupId, member)
+            .orElseThrow(TodoGroupErrorCode.TODO_GROUP_NOT_FOUND::toException);
+
+        Map<TodoCategory, List<GetOneTodoResponseDto>> groupedMap =
+            todoGroup.getTodo().stream()
+                .map(GetOneTodoResponseDto::from)
+                .collect(Collectors.groupingBy(
+                    GetOneTodoResponseDto::todoCategory, LinkedHashMap::new, Collectors.toList()
+                ));
+
+        List<GetTodoGroupByCategoryResponseDto> todos = Arrays.stream(TodoCategory.values())
+            .filter(groupedMap::containsKey)
+            .map(category -> GetTodoGroupByCategoryResponseDto.of(category,
+                groupedMap.get(category)))
+            .collect(Collectors.toList());
+
+        return GetOneTodoGroupResponseDto.of(member, todoGroup, todos);
+
+    }
 }

--- a/src/main/java/com/dodream/todo/dto/response/GetOthersTodoSimpleResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOthersTodoSimpleResponseDto.java
@@ -1,0 +1,27 @@
+package com.dodream.todo.dto.response;
+
+import com.dodream.todo.domain.Todo;
+import com.dodream.todo.domain.TodoGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record GetOthersTodoSimpleResponseDto(
+
+    @Schema(description = "투두 그룹 id", example = "12")
+    Long todoGroupId,
+    @Schema(description = "멤버 닉네임", example = "두둠칫")
+    String memberNickname,
+    @Schema(description = "투두 개수", example = "12")
+    Long todoCount
+) {
+
+    public static GetOthersTodoSimpleResponseDto of(TodoGroup todoGroup, Long todoCount) {
+        return GetOthersTodoSimpleResponseDto.builder()
+            .todoGroupId(todoGroup.getId())
+            .memberNickname(todoGroup.getMember().getNickName())
+            .todoCount(todoCount)
+            .build();
+    }
+
+}

--- a/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
+++ b/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
@@ -2,14 +2,19 @@ package com.dodream.todo.presentation.controller;
 
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.todo.application.TodoService;
+import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.dto.response.GetOthersTodoSimpleResponseDto;
 import com.dodream.todo.presentation.swagger.TodoSwagger;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,5 +31,31 @@ public class TodoController implements TodoSwagger {
         return ResponseEntity.ok(
             new RestResponse<>(todoService.getOneTodoGroupAtHome()));
     }
+
+    @Override
+    @GetMapping(value = "/other/simple/{jobId}")
+    public ResponseEntity<RestResponse<List<GetOthersTodoSimpleResponseDto>>> getOthersTodoSimpleByJob(
+        @PathVariable Long jobId) {
+        return ResponseEntity.ok(
+            new RestResponse<>(todoService.getOthersTodoSimple(jobId)));
+    }
+
+
+    @Override
+    @GetMapping(value = "/other/{jobId}")
+    public ResponseEntity<RestResponse<Page<GetOthersTodoGroupResponseDto>>> getOthersTodoByJob(
+        @PathVariable Long jobId, @RequestParam(defaultValue = "0") int page) {
+        return ResponseEntity.ok(
+            new RestResponse<>(todoService.getOthersTodoByJob(jobId,page)));
+    }
+
+    @Override
+    @GetMapping(value = "/{todoGroupId}")
+    public ResponseEntity<RestResponse<GetOneTodoGroupResponseDto>> getOneOthersTodoGroup(
+        @PathVariable Long todoGroupId) {
+        return ResponseEntity.ok(
+            new RestResponse<>(todoService.getOneOthersTodoGroup(todoGroupId)));
+    }
+
 
 }

--- a/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
+++ b/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
@@ -2,23 +2,55 @@ package com.dodream.todo.presentation.swagger;
 
 import com.dodream.core.config.swagger.ApiErrorCode;
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.dto.response.GetOthersTodoSimpleResponseDto;
 import com.dodream.todo.exception.TodoErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Todo - 홈화면", description = "홈화면 - 투두 리스트 관련 API")
 public interface TodoSwagger {
 
     @Operation(
         summary = "홈화면 - 홈화면 타유저 투두 리스트 목록 조회 API",
-        description = "홈화면에서  타유저 투두 리스트 목록 조회 API",
+        description = "홈화면에서  타유저 투두 리스트 목록 조회",
         operationId = "/v1/todo/other"
     )
     @ApiErrorCode(TodoErrorCode.class)
     ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupAtHome();
+
+    @Operation(
+        summary = "직업 정보 페이지 - 타유저 투두 리스트 목록 조회 API",
+        description = "직업 정보 페이지 우측 상단 - 타유저 투두 리스트 목록 조회",
+        operationId = "/v1/todo/other/simple/{jobId}"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<List<GetOthersTodoSimpleResponseDto>>> getOthersTodoSimpleByJob(
+        @PathVariable Long jobId);
+
+    @Operation(
+        summary = "특정 직업 - 타유저 투두 리스트 목록 조회 API",
+        description = "(직업 정보 페이지에서 [더 보러가기] 클릭시, 특정 직업에 대한 타유저 투두 리스트 목록 조회 ",
+        operationId = "/v1/todo/other/{jobId}"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<Page<GetOthersTodoGroupResponseDto>>> getOthersTodoByJob(
+        @PathVariable Long jobId, @RequestParam(defaultValue = "0") int page);
+
+    @Operation(
+        summary = "타유저 투두 리스트 상세 조회 API",
+        description = "타유저 투두 리스트를 상세 조회",
+        operationId = "/v1/todo/{todoGroupId}}"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<GetOneTodoGroupResponseDto>> getOneOthersTodoGroup(
+        @PathVariable Long todoGroupId);
 
 
 }

--- a/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
@@ -5,6 +5,7 @@ import com.dodream.member.domain.Member;
 import com.dodream.todo.domain.TodoGroup;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,8 @@ import org.springframework.data.repository.query.Param;
 public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
 
     Optional<TodoGroup> findByIdAndMember(Long id, Member member);
+
+    Optional<TodoGroup> findByIdAndMemberNot(Long id, Member member);
 
     List<TodoGroup> findAllByMember(Member member);
 
@@ -23,10 +26,21 @@ public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
     boolean existsByMemberAndJob(Member member, Job job);
 
     @Query("SELECT tg FROM TodoGroup tg " +
-           "WHERE tg.member <> :currentMember " +
-           "AND tg.job = :job " +
-           "AND tg.deleted = false")
-    List<TodoGroup> findTop3ByJobAndNotMember(@Param("job") Job job, @Param("currentMember") Member currentMember, Pageable pageable);
+        "WHERE tg.member <> :currentMember " +
+        "AND tg.job = :job " +
+        "AND tg.deleted = false")
+    List<TodoGroup> findTop3ByJobAndNotMember(@Param("job") Job job,
+        @Param("currentMember") Member currentMember, Pageable pageable);
+
+    @Query("SELECT tg FROM TodoGroup tg " +
+        "WHERE tg.member <> :currentMember " +
+        "AND tg.job = :job " +
+        "AND tg.deleted = false")
+    Page<TodoGroup> findTop10ByJobAndNotMember(@Param("job") Job job,
+        @Param("currentMember") Member currentMember, Pageable pageable);
 
     List<TodoGroup> findTop3ByMemberOrderByTotalViewDesc(Member member);
+
+    List<TodoGroup> findTop5ByJobAndMemberNot(Job job, Member member);
+
 }

--- a/src/main/java/com/dodream/todo/repository/TodoRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoRepository.java
@@ -17,6 +17,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("SELECT t FROM Todo t WHERE t.todoGroup = :group AND t.deleted = false ORDER BY t.createdAt DESC")
     List<Todo> findTop2ByTodoGroup(@Param("group") TodoGroup group, Pageable pageable);
 
+    @Query("SELECT t FROM Todo t WHERE t.todoGroup = :group AND t.deleted = false ORDER BY t.createdAt DESC")
+    List<Todo> findTop3ByTodoGroup(@Param("group") TodoGroup group, Pageable pageable);
+
     @Query("SELECT COUNT(t) FROM Todo t WHERE t.todoGroup = :group AND t.deleted = false")
     Long countByTodoGroup(@Param("group") TodoGroup group);
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 직업 정보조회 - 타유저 투두 리스트 간편 목록 조회
- 더보러가기 클릭시, 타유저 투두 리스트 목록 조회 (10개 단위)
- 타유저 개별 투두 리스트 조회

## ✏️ 관련 이슈
#158 
