### PR TITLE
feat(#165) : 나의 계정 api, 관심 직업 변경 api를 추가한다.

### DIFF
--- a/src/main/java/com/dodream/member/application/MemberService.java
+++ b/src/main/java/com/dodream/member/application/MemberService.java
@@ -132,6 +132,7 @@ public class MemberService {
 
     }
 
+    @Transactional
     public DeleteTodoGroupResponseDto deleteInterestedJobs(ChangeMemberJobsRequestDto requestDto){
 
         Member member = memberAuthService.getCurrentMember();

--- a/src/main/java/com/dodream/member/domain/Member.java
+++ b/src/main/java/com/dodream/member/domain/Member.java
@@ -54,7 +54,7 @@ public class Member extends BaseLongIdEntity {
     private String profileImage;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "region_id")
+    @JoinColumn(name = "region_id", nullable = false)
     private Region region;
 
 

--- a/src/main/java/com/dodream/member/dto/request/ChangeMemberJobsRequestDto.java
+++ b/src/main/java/com/dodream/member/dto/request/ChangeMemberJobsRequestDto.java
@@ -1,0 +1,13 @@
+package com.dodream.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record ChangeMemberJobsRequestDto(
+
+    @Schema(description = "삭제할 관심 직업 id")
+    List<Long> jobIds
+
+) {
+
+}

--- a/src/main/java/com/dodream/member/dto/response/GetMemberInfoResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/GetMemberInfoResponseDto.java
@@ -1,0 +1,44 @@
+package com.dodream.member.dto.response;
+
+import com.dodream.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GetMemberInfoResponseDto(
+
+    @Schema(description = "멤버 id(DB상)", example = "1")
+    Long memberId,
+    @Schema(description = "프로필", example = "www.kr.sdfsd.com/member/1/image.png")
+    String profileImage,
+    @Schema(description = "닉네임", example = "두둠칫")
+    String nickname,
+    @Schema(description = "로그인 아이디", example = "dodream")
+    String loginId,
+    @Schema(description = "생년월일", example = "2001/01/05", type = "string")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy/MM/dd")
+    LocalDate birthDate,
+    @Schema(description = "거주지", example = "서울시 강동구")
+    String regionName,
+    @Schema(description = "관심 직업")
+    List<GetMemberInterestedJobResponseDto> jobs
+) {
+
+    public static GetMemberInfoResponseDto of(Member member,
+        List<GetMemberInterestedJobResponseDto> jobs) {
+        return GetMemberInfoResponseDto.builder()
+            .memberId(member.getId())
+            .profileImage(member.getProfileImage())
+            .nickname(member.getNickName())
+            .loginId(member.getLoginId())
+            .birthDate(member.getBirthDate())
+            .regionName(member.getRegion().getRegionName())
+            .jobs(jobs)
+            .build();
+
+    }
+
+}

--- a/src/main/java/com/dodream/member/dto/response/GetMemberInterestedJobResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/GetMemberInterestedJobResponseDto.java
@@ -1,0 +1,18 @@
+package com.dodream.member.dto.response;
+
+import com.dodream.job.domain.Job;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetMemberInterestedJobResponseDto(
+    @Schema(description = "직업 id", example = "12")
+    Long jobId,
+    @Schema(description = "직업명", example = "요양보호사")
+    String jobName
+
+) {
+
+    public static GetMemberInterestedJobResponseDto from(Job job) {
+        return new GetMemberInterestedJobResponseDto(job.getId(), job.getJobName());
+    }
+
+}

--- a/src/main/java/com/dodream/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/dodream/member/presentation/controller/MemberController.java
@@ -3,20 +3,25 @@ package com.dodream.member.presentation.controller;
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.member.application.MemberService;
 import com.dodream.member.dto.request.ChangeMemberBirthDateRequestDto;
+import com.dodream.member.dto.request.ChangeMemberJobsRequestDto;
 import com.dodream.member.dto.request.ChangeMemberNickNameRequestDto;
 import com.dodream.member.dto.request.ChangeMemberPasswordRequestDto;
 import com.dodream.member.dto.request.ChangeMemberRegionRequestDto;
 import com.dodream.member.dto.response.ChangeMemberBirthDateResponseDto;
 import com.dodream.member.dto.response.ChangeMemberNickNameResponseDto;
 import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
+import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.presentation.swagger.MemberSwagger;
+import com.dodream.todo.dto.response.DeleteTodoGroupResponseDto;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -77,5 +82,21 @@ public class MemberController implements MemberSwagger {
             new RestResponse<>(memberService.changeMemberRegion(changeMemberRegionCodeRequestDto)));
     }
 
+    @Override
+    @DeleteMapping("/job")
+    public ResponseEntity<RestResponse<DeleteTodoGroupResponseDto>> changeMemberInterestedJobs(
+        @RequestBody
+        ChangeMemberJobsRequestDto changeMemberJobsRequestDto) {
+        return ResponseEntity.ok(
+            new RestResponse<>(memberService.deleteInterestedJobs(changeMemberJobsRequestDto)));
+    }
+
+
+    @Override
+    @GetMapping("/info")
+    public ResponseEntity<RestResponse<GetMemberInfoResponseDto>> getMemberInfo() {
+        return ResponseEntity.ok(
+            new RestResponse<>(memberService.getMemberInfo()));
+    }
 
 }

--- a/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
+++ b/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
@@ -3,14 +3,17 @@ package com.dodream.member.presentation.swagger;
 import com.dodream.core.config.swagger.ApiErrorCode;
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.member.dto.request.ChangeMemberBirthDateRequestDto;
+import com.dodream.member.dto.request.ChangeMemberJobsRequestDto;
 import com.dodream.member.dto.request.ChangeMemberNickNameRequestDto;
 import com.dodream.member.dto.request.ChangeMemberPasswordRequestDto;
 import com.dodream.member.dto.request.ChangeMemberRegionRequestDto;
 import com.dodream.member.dto.response.ChangeMemberBirthDateResponseDto;
 import com.dodream.member.dto.response.ChangeMemberNickNameResponseDto;
 import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
+import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.exception.MemberErrorCode;
+import com.dodream.todo.dto.response.DeleteTodoGroupResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -66,6 +69,24 @@ public interface MemberSwagger {
     @ApiErrorCode(MemberErrorCode.class)
     ResponseEntity<RestResponse<ChangeMemberRegionResponseDto>> changeMemberRegion(
         @RequestBody @Valid ChangeMemberRegionRequestDto changeMemberRegionCodeRequestDto);
+
+    @Operation(
+        summary = "관심 직업 변경 API",
+        description = "관심 직업을 변경한다.",
+        operationId = "/v1/member/job"
+    )
+    @ApiErrorCode(MemberErrorCode.class)
+    ResponseEntity<RestResponse<DeleteTodoGroupResponseDto>> changeMemberInterestedJobs(
+        @RequestBody @Valid ChangeMemberJobsRequestDto changeMemberJobsRequestDto);
+
+
+    @Operation(
+        summary = "나의 계정 조회 API",
+        description = "나의 계정 상세 정보를 조회한다.",
+        operationId = "/v1/member/info"
+    )
+    @ApiErrorCode(MemberErrorCode.class)
+    ResponseEntity<RestResponse<GetMemberInfoResponseDto>> getMemberInfo();
 
 
 }

--- a/src/main/java/com/dodream/todo/application/TodoService.java
+++ b/src/main/java/com/dodream/todo/application/TodoService.java
@@ -40,7 +40,6 @@ public class TodoService {
     private final TodoGroupRepository todoGroupRepository;
     private final JobRepository jobRepository;
 
-
     @Transactional(readOnly = true)
     public List<GetOthersTodoGroupResponseDto> getOneTodoGroupAtHome() {
 
@@ -82,11 +81,8 @@ public class TodoService {
                 return GetOthersTodoSimpleResponseDto.of(group, todoCount);
             })
             .collect(Collectors.toList());
-
     }
 
-
-    // 특정 직업에 대한 타 유저 투두 리스트 조회( 전체 )
     @Transactional(readOnly = true)
     public Page<GetOthersTodoGroupResponseDto> getOthersTodoByJob(Long jobId, int page) {
 
@@ -109,10 +105,8 @@ public class TodoService {
             .toList();
 
         return new PageImpl<>(result, pageable, todoGroups.getTotalElements());
-
     }
 
-    // 타유저 - 세부 조회
     @Transactional(readOnly = true)
     public GetOneTodoGroupResponseDto getOneOthersTodoGroup(Long TodoGroupId) {
 
@@ -135,6 +129,5 @@ public class TodoService {
             .collect(Collectors.toList());
 
         return GetOneTodoGroupResponseDto.of(member, todoGroup, todos);
-
     }
 }

--- a/src/main/java/com/dodream/todo/domain/Todo.java
+++ b/src/main/java/com/dodream/todo/domain/Todo.java
@@ -63,10 +63,6 @@ public class Todo extends BaseLongIdEntity {
     @OneToMany(mappedBy = "todo", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TodoImage> images = new ArrayList<>();
 
-    public void updateDeleted() {
-        this.deleted = true;
-    }
-
     public void updateCompleted() {
         this.completed = !this.completed;
     }

--- a/src/main/java/com/dodream/todo/domain/TodoImage.java
+++ b/src/main/java/com/dodream/todo/domain/TodoImage.java
@@ -32,8 +32,4 @@ public class TodoImage extends BaseLongIdEntity {
     @Column(nullable = false)
     private String imageUrl;
 
-    public void updateDeleted() {
-         this.deleted = true;
-     }
-
 }

--- a/src/main/java/com/dodream/todo/dto/response/DeleteTodoGroupResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/DeleteTodoGroupResponseDto.java
@@ -1,0 +1,19 @@
+package com.dodream.todo.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record DeleteTodoGroupResponseDto(
+    @Schema(description = "삭제된 관심 직업 id 목록")
+    List<Long> deletedJobIds,
+
+    @Schema(description = "메세지", example = "관심직업이 변경되었습니다")
+    String message
+
+) {
+
+    public static DeleteTodoGroupResponseDto from(List<Long> deletedJobId) {
+        return new DeleteTodoGroupResponseDto(deletedJobId, "관심직업이 변경되었습니다");
+    }
+}
+

--- a/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
@@ -43,4 +43,6 @@ public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
 
     List<TodoGroup> findTop5ByJobAndMemberNot(Job job, Member member);
 
+    List<TodoGroup> deleteByMemberAndJobIdIn(Member member,List<Long> jobId);
+
 }

--- a/src/main/java/com/dodream/todo/repository/TodoRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
-    Optional<Todo> findByIdAndMemberAndDeletedIsFalse(Long todoId, Member member);
+    Optional<Todo> findByIdAndMember(Long todoId, Member member);
 
     @Query("SELECT t FROM Todo t WHERE t.todoGroup = :group AND t.deleted = false ORDER BY t.createdAt DESC")
     List<Todo> findTop2ByTodoGroup(@Param("group") TodoGroup group, Pageable pageable);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 거주지 -> Not null 로 변경
- 나의 계정 - 정보 조회 api 추가
- 관심 직업 변경 api를 추가

## ✏️ 관련 이슈
#165 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 회원의 관심 직업(관심 직업 그룹) 정보를 조회하는 API가 추가되었습니다.
    - 회원의 관심 직업을 삭제(변경)하는 API가 추가되었습니다.

- **버그 수정**
    - 회원의 지역 정보가 반드시 입력되도록 개선되었습니다.

- **리팩터**
    - 회원 정보 및 관심 직업 관련 서비스 내부 구조가 일관성 있게 개선되었습니다.

- **기타**
    - 관심 직업 삭제 시 하드 삭제 방식으로 변경되었습니다.
    - 관심 직업 관련 응답 및 요청 데이터 구조가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->