### PR TITLE
Feat(#175): 훈련과정에 마감일 정렬 필터를 추가한다.

### DIFF
--- a/src/main/java/com/dodream/training/application/BootcampService.java
+++ b/src/main/java/com/dodream/training/application/BootcampService.java
@@ -3,6 +3,7 @@ package com.dodream.training.application;
 import com.dodream.training.dto.response.TrainingDetailApiResponse;
 import com.dodream.training.dto.response.TrainingListApiResponse;
 import com.dodream.training.infrastructure.mapper.TrainingMapper;
+import com.dodream.training.presentation.value.SortBy;
 import com.dodream.training.util.TrainingCodeResolver;
 import com.dodream.training.util.executer.TrainingApiExecuter;
 import lombok.extern.log4j.Log4j2;
@@ -33,13 +34,13 @@ public class BootcampService{
     }
 
     public TrainingListApiResponse getList(
-            String pageNum, String regionName, String jobName
+            String pageNum, String regionName, String jobName, SortBy sortBy
     ) {
         String regionCode = trainingCodeResolver.resolveRegionCode(regionName);
         String ncsCode = trainingCodeResolver.resolveNcsCode(jobName);
 
         String result = trainingApiExecuter.callListApi(
-                pageNum, regionCode, ncsCode
+                pageNum, regionCode, ncsCode, sortBy
         );
 
         TrainingListApiResponse response = listMapper.jsonToResponseDto(result);

--- a/src/main/java/com/dodream/training/application/DualTrainingService.java
+++ b/src/main/java/com/dodream/training/application/DualTrainingService.java
@@ -3,6 +3,7 @@ package com.dodream.training.application;
 import com.dodream.training.dto.response.TrainingDetailApiResponse;
 import com.dodream.training.dto.response.TrainingListApiResponse;
 import com.dodream.training.infrastructure.mapper.TrainingMapper;
+import com.dodream.training.presentation.value.SortBy;
 import com.dodream.training.util.TrainingCodeResolver;
 import com.dodream.training.util.executer.TrainingApiExecuter;
 import lombok.extern.log4j.Log4j2;
@@ -32,13 +33,13 @@ public class DualTrainingService {
     }
 
     public TrainingListApiResponse getList(
-            String pageNum, String regionName, String ncsName
+            String pageNum, String regionName, String ncsName, SortBy sortBy
     ) {
         String regionCode = trainingCodeResolver.resolveRegionCode(regionName);
         String ncsCode = trainingCodeResolver.resolveNcsCode(ncsName);
 
         String result = trainingApiExecuter.callListApi(
-                pageNum, regionCode, ncsCode
+                pageNum, regionCode, ncsCode, sortBy
         );
 
         TrainingListApiResponse response = listMapper.jsonToResponseDto(result);

--- a/src/main/java/com/dodream/training/infrastructure/caller/BootCampApiCaller.java
+++ b/src/main/java/com/dodream/training/infrastructure/caller/BootCampApiCaller.java
@@ -3,6 +3,7 @@ package com.dodream.training.infrastructure.caller;
 import com.dodream.core.infrastructure.cache.annotation.CustomCacheableWithLock;
 import com.dodream.training.exception.TrainingErrorCode;
 import com.dodream.training.infrastructure.feign.BootcampFeignClient;
+import com.dodream.training.presentation.value.SortBy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +31,7 @@ public class BootCampApiCaller implements TrainingApiCaller{
     @Override
     @CustomCacheableWithLock(cacheName = "bootcampList", ttl = 15)
     public String getListApi(
-            String pageNum, String regionCode, String ncsCode
+            String pageNum, String regionCode, String ncsCode, SortBy sortBy
     ){
         try {
             log.info("[searchBootCampList] 메소드 실행");
@@ -42,8 +43,8 @@ public class BootCampApiCaller implements TrainingApiCaller{
                     String.valueOf(pageSize),
                     regionCode,
                     ncsCode,
-                    SORT,
-                    SORT_COLUMN
+                    sortBy.getSort(),
+                    sortBy.getSortCol()
             );
         } catch (Exception e) {
             throw TrainingErrorCode.NOT_CONNECT_EXTERNAL_API.toException();

--- a/src/main/java/com/dodream/training/infrastructure/caller/DualTrainingApiCaller.java
+++ b/src/main/java/com/dodream/training/infrastructure/caller/DualTrainingApiCaller.java
@@ -4,6 +4,7 @@ import com.dodream.core.infrastructure.cache.annotation.CustomCacheable;
 import com.dodream.core.infrastructure.cache.annotation.CustomCacheableWithLock;
 import com.dodream.training.exception.TrainingErrorCode;
 import com.dodream.training.infrastructure.feign.DualTrainingFeignClient;
+import com.dodream.training.presentation.value.SortBy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -28,7 +29,7 @@ public class DualTrainingApiCaller implements TrainingApiCaller{
 
     @Override
     @CustomCacheableWithLock(cacheName = "dualList", ttl = 15)
-    public String getListApi(String pageNum, String regionCode, String ncsCode) {
+    public String getListApi(String pageNum, String regionCode, String ncsCode, SortBy sortBy) {
         try {
             return dualTrainingFeignClient.getDualTrainingList(
                     apiKey,
@@ -38,8 +39,8 @@ public class DualTrainingApiCaller implements TrainingApiCaller{
                     String.valueOf(pageSize),
                     regionCode,
                     ncsCode,
-                    SORT,
-                    SORT_COLUMN
+                    sortBy.getSort(),
+                    sortBy.getSortCol()
             );
         } catch (Exception e) {
             throw TrainingErrorCode.NOT_CONNECT_EXTERNAL_API.toException();

--- a/src/main/java/com/dodream/training/infrastructure/caller/TrainingApiCaller.java
+++ b/src/main/java/com/dodream/training/infrastructure/caller/TrainingApiCaller.java
@@ -1,8 +1,10 @@
 package com.dodream.training.infrastructure.caller;
 
+import com.dodream.training.presentation.value.SortBy;
+
 public interface TrainingApiCaller {
     String getListApi(
-            String pageNum, String regionCode, String ncsCode
+            String pageNum, String regionCode, String ncsCode, SortBy sortBy
     );
 
     String getDetailApi(

--- a/src/main/java/com/dodream/training/presentation/controller/TrainingController.java
+++ b/src/main/java/com/dodream/training/presentation/controller/TrainingController.java
@@ -7,6 +7,7 @@ import com.dodream.scrap.domain.value.TrainingType;
 import com.dodream.training.dto.response.TrainingDetailApiResponse;
 import com.dodream.training.dto.response.TrainingListApiResponse;
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.training.presentation.value.SortBy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,17 +29,20 @@ public class TrainingController implements TrainingSwagger {
         @RequestParam String pageNum,
         @RequestParam(required = false) String type,
         @RequestParam(required = false) String regionName,
-        @RequestParam(required = false) String jobName
+        @RequestParam(required = false) String jobName,
+        @RequestParam(required = false) String sortBy
     ){
-        if(TrainingType.DUAL.getDescription().equals(type)){
-            return ResponseEntity.ok(new RestResponse<>(
-                    dualTrainingService.getList(pageNum, regionName, jobName)
-            ));
-        }else{
-            return ResponseEntity.ok(new RestResponse<>(
-                    bootcampService.getList(pageNum, regionName, jobName))
-            );
+
+        SortBy sort = SortBy.DEADLINE_ASC;
+        if (SortBy.DEADLINE_DESC.getName().equals(sortBy)) {
+            sort = SortBy.DEADLINE_DESC;
         }
+
+        TrainingListApiResponse response = TrainingType.DUAL.getDescription().equals(type)
+                ? dualTrainingService.getList(pageNum, regionName, jobName, sort)
+                : bootcampService.getList(pageNum, regionName, jobName, sort);
+
+        return ResponseEntity.ok(new RestResponse<>(response));
     }
 
     @GetMapping("/detail")

--- a/src/main/java/com/dodream/training/presentation/swagger/TrainingSwagger.java
+++ b/src/main/java/com/dodream/training/presentation/swagger/TrainingSwagger.java
@@ -35,7 +35,11 @@ public interface TrainingSwagger {
 
             @RequestParam(required = false)
             @Parameter(description = "/v1/job/list를 호출하여 나오는 직업의 이름", example = "요양보호사")
-            String jobName
+            String jobName,
+            
+            @RequestParam(required = false)
+            @Parameter(description = "정렬 관련 필터(마감순 정렬, 채용정보와 일치함)", example = "마감 임박순")
+            String sortBy
     );
 
     @Operation(

--- a/src/main/java/com/dodream/training/presentation/value/SortBy.java
+++ b/src/main/java/com/dodream/training/presentation/value/SortBy.java
@@ -1,0 +1,16 @@
+package com.dodream.training.presentation.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortBy {
+
+    DEADLINE_ASC("2", "ASC","마감 임박순"),
+    DEADLINE_DESC("2", "DESC", "마감 여유순");
+
+    private final String sort;
+    private final String sortCol;
+    private final String name;
+}

--- a/src/main/java/com/dodream/training/presentation/value/SortBy.java
+++ b/src/main/java/com/dodream/training/presentation/value/SortBy.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SortBy {
 
-    DEADLINE_ASC("2", "ASC","마감 임박순"),
-    DEADLINE_DESC("2", "DESC", "마감 여유순");
+    DEADLINE_ASC("ASC", "2","마감 임박순"),
+    DEADLINE_DESC("DESC", "2", "마감 여유순");
 
     private final String sort;
     private final String sortCol;

--- a/src/main/java/com/dodream/training/util/executer/BootcampApiExecuter.java
+++ b/src/main/java/com/dodream/training/util/executer/BootcampApiExecuter.java
@@ -1,6 +1,7 @@
 package com.dodream.training.util.executer;
 
 import com.dodream.training.infrastructure.caller.TrainingApiCaller;
+import com.dodream.training.presentation.value.SortBy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -12,10 +13,10 @@ public class BootcampApiExecuter implements TrainingApiExecuter {
 
     @Override
     public String callListApi(
-            String pageNum, String regionCode, String ncsCode
+            String pageNum, String regionCode, String ncsCode, SortBy sortBy
     ) {
         return trainingApiCaller.getListApi(
-                pageNum, regionCode, ncsCode
+                pageNum, regionCode, ncsCode, sortBy
         );
     }
 

--- a/src/main/java/com/dodream/training/util/executer/DualTrainingApiExecuter.java
+++ b/src/main/java/com/dodream/training/util/executer/DualTrainingApiExecuter.java
@@ -1,6 +1,7 @@
 package com.dodream.training.util.executer;
 
 import com.dodream.training.infrastructure.caller.TrainingApiCaller;
+import com.dodream.training.presentation.value.SortBy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -12,9 +13,9 @@ public class DualTrainingApiExecuter implements TrainingApiExecuter {
     private final TrainingApiCaller trainingApiCaller;
 
     @Override
-    public String callListApi(String pageNum, String regionCode, String ncsCode) {
+    public String callListApi(String pageNum, String regionCode, String ncsCode, SortBy sortBy) {
         return trainingApiCaller.getListApi(
-                pageNum, regionCode, ncsCode
+                pageNum, regionCode, ncsCode, sortBy
         );
     }
 

--- a/src/main/java/com/dodream/training/util/executer/TrainingApiExecuter.java
+++ b/src/main/java/com/dodream/training/util/executer/TrainingApiExecuter.java
@@ -1,8 +1,10 @@
 package com.dodream.training.util.executer;
 
+import com.dodream.training.presentation.value.SortBy;
+
 public interface TrainingApiExecuter {
     String callListApi(
-            String pageNum, String regionCode, String ncsCode
+            String pageNum, String regionCode, String ncsCode, SortBy sortBy
     );
 
     String callDetailApi(


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 훈련 과정 검색시 마감 임박, 마감 여유 순으로 필터링 가능하게 설정했습니다.

## ✏️ 관련 이슈
#175 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 부트캠프 및 이중훈련 목록 조회 시 마감일 기준 오름차순/내림차순 정렬 기능이 추가되었습니다.
  - 정렬 기준(sortBy) 파라미터를 통해 원하는 순서로 목록을 조회할 수 있습니다.

- **Documentation**
  - 정렬 기준 파라미터에 대한 설명이 API 문서에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->