### PR TITLE
Feat(#197) : 비로그인 상태에서 드리머의 투두 목록을 조회하는 api를 구현한다.

### DIFF
--- a/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
@@ -33,7 +33,8 @@ public class SecurityConfiguration {
         "/v1/member/auth/check-nickname/**",
         "/v1/member/auth/login",
         "/v1/clova/**",
-        "/v1/job/**"
+        "/v1/job/**",
+        "/v1/todo/other/public"
     };
 
     @Bean

--- a/src/main/java/com/dodream/todo/domain/TodoGroup.java
+++ b/src/main/java/com/dodream/todo/domain/TodoGroup.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -44,5 +45,9 @@ public class TodoGroup extends BaseLongIdEntity {
 
     @Builder.Default
     private Long totalView = 0L;
+
+    public void updateTotalView() {
+         this.totalView++;
+     }
 
 }

--- a/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
+++ b/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
@@ -33,13 +33,19 @@ public class TodoController implements TodoSwagger {
     }
 
     @Override
+    @GetMapping(value = "/other/public")
+    public ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupPublicAtHome() {
+        return ResponseEntity.ok(
+            new RestResponse<>(todoService.getOneTodoGroupPublicAtHome()));
+    }
+
+    @Override
     @GetMapping(value = "/other/simple/{jobId}")
     public ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOthersTodoSimpleByJob(
         @PathVariable Long jobId) {
         return ResponseEntity.ok(
             new RestResponse<>(todoService.getOthersTodoSimple(jobId)));
     }
-
 
     @Override
     @GetMapping(value = "/other/{jobId}")

--- a/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
+++ b/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
@@ -27,6 +27,16 @@ public interface TodoSwagger {
     @ApiErrorCode(TodoErrorCode.class)
     ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupAtHome();
 
+
+    @Operation(
+        summary = "[비로그인 상태] 홈화면 - 드리머 투두 리스트 목록 조회 API",
+        description = "[비로그인 상태] 홈화면에서 드리머 투두 리스트 목록 조회",
+        operationId = "/v1/todo/other/public"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<List<GetOthersTodoGroupResponseDto>>> getOneTodoGroupPublicAtHome();
+
+
     @Operation(
         summary = "직업 정보 페이지 - 타유저 투두 리스트 목록 조회 API",
         description = "직업 정보 페이지 우측 상단 - 타유저 투두 리스트 목록 조회",
@@ -55,13 +65,13 @@ public interface TodoSwagger {
         @PathVariable Long todoGroupId);
 
     @Operation(
-         summary = "타유저 투두 리스트 메모 조회 API",
-         description = "타유저 투두 리스트의 메모 조회",
-         operationId = "/v1/todo/{todoId}/memo}"
-     )
-     @ApiErrorCode(TodoErrorCode.class)
-     ResponseEntity<RestResponse<GetOneTodoWithMemoResponseDto>> getOneOthersTodoMemo(
-         @PathVariable Long todoId);
+        summary = "타유저 투두 리스트 메모 조회 API",
+        description = "타유저 투두 리스트의 메모 조회",
+        operationId = "/v1/todo/{todoId}/memo}"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<GetOneTodoWithMemoResponseDto>> getOneOthersTodoMemo(
+        @PathVariable Long todoId);
 
 
 }

--- a/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoGroupRepository.java
@@ -41,7 +41,8 @@ public interface TodoGroupRepository extends JpaRepository<TodoGroup, Long> {
 
     List<TodoGroup> findTop3ByMemberOrderByTotalViewDesc(Member member);
 
-    List<TodoGroup> findTop5ByJobAndMemberNot(Job job, Member member);
+    @Query("SELECT tg FROM TodoGroup tg ORDER BY tg.totalView DESC")
+    List<TodoGroup> findTop3ByTotalView(Pageable pageable);
 
     List<TodoGroup> deleteByMemberAndJobIdIn(Member member,List<Long> jobId);
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 비로그인 상태에서 드리머의 투두 목록을 조회하는 api를 구현
- securityConfig의 whitelist 수정

## ✏️ 관련 이슈
#197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 비로그인 사용자를 위한 인기 투두 그룹(상위 3개) 공개 조회 API가 추가되었습니다. 홈 화면에서 누구나 인기 투두 그룹과 일부 투두 목록을 확인할 수 있습니다.

- **버그 수정**
  - 타인의 투두 그룹 조회 시 조회수가 정상적으로 증가하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->