### PR TITLE
Fix(#204): 훈련비용이 0원으로 저장되는 오류를 수정한다.

### DIFF
--- a/src/main/java/com/dodream/scrap/domain/entity/MemberTrainingScrap.java
+++ b/src/main/java/com/dodream/scrap/domain/entity/MemberTrainingScrap.java
@@ -80,9 +80,17 @@ public class MemberTrainingScrap extends BaseLongIdEntity {
                 .trainingStartDate(LocalDate.parse(request.traStartDate(), formatter))
                 .trainingEndDate(LocalDate.parse(request.traEndDate(), formatter))
                 .trainingDegree(String.valueOf(response.instBaseInfo().trprDegr()))
-                .trainingManage(response.instBaseInfo().instPerTrco())
+                .trainingManage(getIntegerPrice(response.instDetailInfo().totalCrsAt()))
                 .trainingUrl(response.instBaseInfo().hpAddr())
                 .member(member)
                 .build();
+    }
+
+    private static int getIntegerPrice(String price){
+        try{
+            return Integer.parseInt(price);
+        }catch (NumberFormatException e){
+            return 0;
+        }
     }
 }

--- a/src/main/java/com/dodream/training/dto/response/TrainingDetailApiResponse.java
+++ b/src/main/java/com/dodream/training/dto/response/TrainingDetailApiResponse.java
@@ -6,7 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record TrainingDetailApiResponse(
 
         @JsonProperty("inst_base_info")
-        InstBaseInfo instBaseInfo
+        InstBaseInfo instBaseInfo,
+
+        @JsonProperty("inst_detail_info")
+        InstDetailInfo instDetailInfo
 ) {
     public record InstBaseInfo(
             @JsonProperty("hpAddr")
@@ -32,5 +35,10 @@ public record TrainingDetailApiResponse(
             @JsonProperty("instPerTrco")
             @Schema(description = "실제 훈련비", example = "250000")
             int instPerTrco
+    ){}
+
+    public record InstDetailInfo(
+            @JsonProperty("totalCrsAt")
+            String totalCrsAt
     ){}
 }

--- a/src/test/java/com/dodream/scrap/application/TrainingScrapServiceTest.java
+++ b/src/test/java/com/dodream/scrap/application/TrainingScrapServiceTest.java
@@ -86,6 +86,7 @@ public class TrainingScrapServiceTest {
     private Member mockMember;
     private Region mockRegion;
     private TrainingDetailApiResponse.InstBaseInfo instBaseInfo;
+    private TrainingDetailApiResponse.InstDetailInfo instDetailInfo;
     private static TrainingDetailApiResponse TEST_DETAIL_RESPONSE;
     private static TrainingSaveReqeustDto TEST_SAVE_REQEUST;
 
@@ -108,6 +109,7 @@ public class TrainingScrapServiceTest {
                 .build();
 
         instBaseInfo = new TrainingDetailApiResponse.InstBaseInfo(
+                "https://~",
                 "경기도 안양시 만안구",
                 3,
                 "요양보호사 자격증 취득 과정 (사회복지사)",
@@ -115,7 +117,9 @@ public class TrainingScrapServiceTest {
                 250000
         );
 
-        TEST_DETAIL_RESPONSE = new TrainingDetailApiResponse(instBaseInfo);
+        instDetailInfo = new TrainingDetailApiResponse.InstDetailInfo("350000");
+
+        TEST_DETAIL_RESPONSE = new TrainingDetailApiResponse(instBaseInfo, instDetailInfo);
         TEST_SAVE_REQEUST = new TrainingSaveReqeustDto(
                 TEST_TRPR_ID, TEST_TRPR_DEG, TEST_TORG_ID, TEST_START_DATE, TEST_END_DATE
         );
@@ -146,10 +150,10 @@ public class TrainingScrapServiceTest {
             given(memberTrainingScrapRepository.existsByTrainingIdAndMemberId(TEST_TRPR_ID, TEST_ID))
                     .willReturn(false);
 
-            given(bootcampApiCaller.getDetailApi(anyString(), anyString(), anyString()))
+            given(bootcampApiCaller.getDetailApi(any(), any(), any()))
                     .willReturn(API_CALLER_RESULT);
 
-            given(trainingDetailResponseDtoMapper.jsonToResponseDto(anyString()))
+            given(trainingDetailResponseDtoMapper.jsonToResponseDto(any()))
                     .willReturn(TEST_DETAIL_RESPONSE);
 
             ArgumentCaptor<MemberTrainingScrap> captor = ArgumentCaptor.forClass(MemberTrainingScrap.class);
@@ -175,10 +179,10 @@ public class TrainingScrapServiceTest {
             given(memberTrainingScrapRepository.existsByTrainingIdAndMemberId(TEST_TRPR_ID, TEST_ID))
                     .willReturn(false);
 
-            given(dualTrainingApiCaller.getDetailApi(anyString(), anyString(), anyString()))
+            given(dualTrainingApiCaller.getDetailApi(any(), any(), any()))
                     .willReturn(API_CALLER_RESULT);
 
-            given(trainingDetailResponseDtoMapper.jsonToResponseDto(anyString()))
+            given(trainingDetailResponseDtoMapper.jsonToResponseDto(any()))
                     .willReturn(TEST_DETAIL_RESPONSE);
 
             ArgumentCaptor<MemberTrainingScrap> captor = ArgumentCaptor.forClass(MemberTrainingScrap.class);

--- a/src/test/java/com/dodream/training/application/AbstractTrainingServiceTest.java
+++ b/src/test/java/com/dodream/training/application/AbstractTrainingServiceTest.java
@@ -53,12 +53,13 @@ public abstract class AbstractTrainingServiceTest<T extends AbstractTrainingServ
     protected final TrainingDetailApiResponse DUMMY_DETAIL =
             new TrainingDetailApiResponse(
                     new TrainingDetailApiResponse.InstBaseInfo(
+                            "https://~",
                             "경기도 안양시 만안구",
                             3,
                             "요양보호사 자격증 과정",
                             "요양보호사 교육기관",
                             123456
-                    )
+                    ), new TrainingDetailApiResponse.InstDetailInfo("350000")
             );
     protected final SortBy DEFAULT_SORT = SortBy.DEADLINE_DESC;
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 훈련비용이 0원으로 저장되지 않도록 실제 훈련비 필드를 조정한다.
## ✏️ 관련 이슈
#204 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - API 응답에 교육 상세 정보(totalCrsAt)가 추가되어 더 상세한 정보를 확인할 수 있습니다.

- **버그 수정**
  - 교육비 필드에 잘못된 값이 입력될 경우 0으로 안전하게 처리되어 오류가 줄어듭니다.

- **테스트**
  - 새로운 교육 상세 정보 필드를 반영하여 테스트 데이터와 테스트 로직이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->