### PR TITLE
feat(#206) : 프로필 삭제 api를 구현한다

### DIFF
--- a/src/main/java/com/dodream/member/dto/response/DeleteMemberProfileImageResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/DeleteMemberProfileImageResponseDto.java
@@ -1,0 +1,18 @@
+package com.dodream.member.dto.response;
+
+import com.dodream.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DeleteMemberProfileImageResponseDto(
+
+    @Schema(description = "멤버 id(DB상)", example = "1")
+    Long memberId,
+    @Schema(description = "메세지", example = "프로필 사진이 삭제되었습니다.")
+    String message
+) {
+
+    public static DeleteMemberProfileImageResponseDto from(Member member) {
+        return new DeleteMemberProfileImageResponseDto(member.getId(), "프로필 사진이 삭제되었습니다.");
+    }
+
+}

--- a/src/main/java/com/dodream/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/dodream/member/exception/MemberErrorCode.java
@@ -10,9 +10,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode<DomainException> {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다"),
+    MEMBER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "삭제할 프로필 이미지가 존재하지 않습니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    DUPLICATE_MEMBER_ID(HttpStatus.CONFLICT,"이미 사용 중인 아이디입니다."),
-    DUPLICATE_NICKNAME(HttpStatus.CONFLICT ,"이미 사용 중인 닉네임입니다."),
+    DUPLICATE_MEMBER_ID(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     MEMBER_INACTIVE(HttpStatus.BAD_REQUEST, "비활성화된 계정입니다."),
     PASSWORD_NOT_SAME(HttpStatus.BAD_REQUEST, "두 비밀번호가 일치하지 않습니다."),
     UNSUPPORTED_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 확장자입니다.(jpg,jpeg,png만 허용)"),

--- a/src/main/java/com/dodream/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/dodream/member/presentation/controller/MemberController.java
@@ -10,6 +10,7 @@ import com.dodream.member.dto.request.ChangeMemberRegionRequestDto;
 import com.dodream.member.dto.response.ChangeMemberBirthDateResponseDto;
 import com.dodream.member.dto.response.ChangeMemberNickNameResponseDto;
 import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
+import com.dodream.member.dto.response.DeleteMemberProfileImageResponseDto;
 import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.presentation.swagger.MemberSwagger;
@@ -45,6 +46,13 @@ public class MemberController implements MemberSwagger {
         @RequestParam("file") MultipartFile file) {
         return ResponseEntity.ok(
             new RestResponse<>(memberService.uploadMemberProfileImage(file)));
+    }
+
+    @Override
+    @DeleteMapping(value = "/profile")
+    public ResponseEntity<RestResponse<DeleteMemberProfileImageResponseDto>> deleteMemberProfileImage() {
+        return ResponseEntity.ok(
+            new RestResponse<>(memberService.deleteMemberProfileImage()));
     }
 
     @Override

--- a/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
+++ b/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
@@ -10,6 +10,7 @@ import com.dodream.member.dto.request.ChangeMemberRegionRequestDto;
 import com.dodream.member.dto.response.ChangeMemberBirthDateResponseDto;
 import com.dodream.member.dto.response.ChangeMemberNickNameResponseDto;
 import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
+import com.dodream.member.dto.response.DeleteMemberProfileImageResponseDto;
 import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.exception.MemberErrorCode;
@@ -33,6 +34,15 @@ public interface MemberSwagger {
     @ApiErrorCode(MemberErrorCode.class)
     ResponseEntity<RestResponse<UploadMemberProfileImageResponseDto>> uploadMemberProfileImage(
         @RequestParam("file") MultipartFile file);
+
+    @Operation(
+        summary = "회원 프로필 사진 삭제 API",
+        description = "기존 프로필 사진을 삭제한다.",
+        operationId = "/v1/member/profile"
+    )
+    @ApiErrorCode(MemberErrorCode.class)
+    ResponseEntity<RestResponse<DeleteMemberProfileImageResponseDto>> deleteMemberProfileImage();
+
 
     @Operation(
         summary = "비밀번호 변경 API",


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 프로필 삭제 api 구현

## ✏️ 관련 이슈
#206 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 회원 프로필 이미지 삭제 기능이 추가되었습니다. 이제 회원은 프로필 이미지를 삭제할 수 있습니다.
- **버그 수정**
  - 일부 메시지의 불필요한 공백이 제거되어 문구가 개선되었습니다.
- **문서화**
  - 프로필 이미지 삭제 관련 API 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->