### PR TITLE
Feat(#160) : 투두 api를 검토하고 테스트 코드를 작성한다.

### DIFF
--- a/src/main/java/com/dodream/todo/domain/Todo.java
+++ b/src/main/java/com/dodream/todo/domain/Todo.java
@@ -58,6 +58,7 @@ public class Todo extends BaseLongIdEntity {
 
     private String link;
 
+    @Builder.Default
     @OneToMany(mappedBy = "todo", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TodoImage> images = new ArrayList<>();
 

--- a/src/test/java/com/dodream/member/application/MemberServiceTest.java
+++ b/src/test/java/com/dodream/member/application/MemberServiceTest.java
@@ -142,8 +142,6 @@ public class MemberServiceTest {
         @DisplayName("닉네임 변경 실패 테스트 - 이미 존재하는 닉네임인 경우")
         void changeMemberNickNameFail() {
 
-//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-//                .thenReturn(Optional.of(mockMember));
             when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             when(memberRepository.existsByNickNameAndState(TEST_NEW_NICKNAME, TEST_STATE))
@@ -162,8 +160,6 @@ public class MemberServiceTest {
         @DisplayName("비밀번호 변경 성공 테스트")
         void changeMemberPasswordSuccess() {
 
-//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-//                .thenReturn(Optional.of(mockMember));
             when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             ChangeMemberPasswordRequestDto requestDto = new ChangeMemberPasswordRequestDto(
@@ -201,8 +197,6 @@ public class MemberServiceTest {
         @DisplayName("생년월일 변경 성공 테스트")
         void changeMemberBirthSuccess() {
 
-//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-//                .thenReturn(Optional.of(mockMember));
             when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             ChangeMemberBirthDateRequestDto requestDto = new ChangeMemberBirthDateRequestDto(
@@ -223,8 +217,6 @@ public class MemberServiceTest {
         @DisplayName("거주지 변경 성공 테스트")
         void changeMemberRegionSuccess() {
 
-//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-//                .thenReturn(Optional.of(mockMember));
             when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             when(regionRepository.findByRegionCode(TEST_REGION_CODE2))

--- a/src/test/java/com/dodream/member/application/MemberServiceTest.java
+++ b/src/test/java/com/dodream/member/application/MemberServiceTest.java
@@ -48,6 +48,8 @@ public class MemberServiceTest {
     private RegionRepository regionRepository;
     @Mock
     private BCryptPasswordEncoder passwordEncoder;
+    @Mock
+    private MemberAuthService memberAuthService;
     @InjectMocks
     private MemberService memberService;
 
@@ -120,8 +122,7 @@ public class MemberServiceTest {
         @DisplayName("닉네임 변경 성공 테스트")
         void changeMemberNickNameSuccess() {
 
-            when(memberRepository.findByIdAndState(1L, TEST_STATE))
-                .thenReturn(Optional.of(mockMember));
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             ChangeMemberNickNameRequestDto requestDto = new ChangeMemberNickNameRequestDto(
                 TEST_NEW_NICKNAME);
@@ -141,8 +142,9 @@ public class MemberServiceTest {
         @DisplayName("닉네임 변경 실패 테스트 - 이미 존재하는 닉네임인 경우")
         void changeMemberNickNameFail() {
 
-            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-                .thenReturn(Optional.of(mockMember));
+//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
+//                .thenReturn(Optional.of(mockMember));
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             when(memberRepository.existsByNickNameAndState(TEST_NEW_NICKNAME, TEST_STATE))
                 .thenReturn(true);
@@ -160,8 +162,9 @@ public class MemberServiceTest {
         @DisplayName("비밀번호 변경 성공 테스트")
         void changeMemberPasswordSuccess() {
 
-            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-                .thenReturn(Optional.of(mockMember));
+//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
+//                .thenReturn(Optional.of(mockMember));
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             ChangeMemberPasswordRequestDto requestDto = new ChangeMemberPasswordRequestDto(
                 TEST_PASSWORD, TEST_PASSWORD);
@@ -181,8 +184,9 @@ public class MemberServiceTest {
         @Test
         @DisplayName("비밀번호 변경 실패 테스트 - 비밀번호 & 비밀번호 확인일 일치하지 않는 경우")
         void changeMemberPasswordFail() {
-            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-                .thenReturn(Optional.of(mockMember));
+//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
+//                .thenReturn(Optional.of(mockMember));
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             ChangeMemberPasswordRequestDto requestDto = new ChangeMemberPasswordRequestDto(
                 TEST_PASSWORD, TEST_WRONG_CHECK_PASSWORD);
@@ -197,8 +201,9 @@ public class MemberServiceTest {
         @DisplayName("생년월일 변경 성공 테스트")
         void changeMemberBirthSuccess() {
 
-            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-                .thenReturn(Optional.of(mockMember));
+//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
+//                .thenReturn(Optional.of(mockMember));
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             ChangeMemberBirthDateRequestDto requestDto = new ChangeMemberBirthDateRequestDto(
                 TEST_NEW_BIRTHDATE);
@@ -218,8 +223,9 @@ public class MemberServiceTest {
         @DisplayName("거주지 변경 성공 테스트")
         void changeMemberRegionSuccess() {
 
-            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
-                .thenReturn(Optional.of(mockMember));
+//            when(memberRepository.findByIdAndState(1L, State.ACTIVE))
+//                .thenReturn(Optional.of(mockMember));
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             when(regionRepository.findByRegionCode(TEST_REGION_CODE2))
                 .thenReturn(Optional.of(region2));
@@ -227,7 +233,8 @@ public class MemberServiceTest {
             ChangeMemberRegionRequestDto requestDto = new ChangeMemberRegionRequestDto(
                 TEST_REGION_CODE2);
 
-            ChangeMemberRegionResponseDto responseDto = memberService.changeMemberRegion(requestDto);
+            ChangeMemberRegionResponseDto responseDto = memberService.changeMemberRegion(
+                requestDto);
 
             assertAll(
                 () -> assertThat(mockMember).isNotNull(),

--- a/src/test/java/com/dodream/todo/application/TodoMemberServiceTest.java
+++ b/src/test/java/com/dodream/todo/application/TodoMemberServiceTest.java
@@ -79,9 +79,11 @@ public class TodoMemberServiceTest {
     private static final String TEST_REGION_CODE1 = "11110";
     private static final String TEST_REGION_NAME1 = "서울 종로구";
     private Member mockMember;
-    private Job job;
+    private Job job1;
+    private Job job2;
     private JobTodo jobTodo;
-    private TodoGroup todoGroup;
+    private TodoGroup todoGroup1;
+    private TodoGroup todoGroup2;
     private Todo todo;
     private Region region1;
 
@@ -111,7 +113,7 @@ public class TodoMemberServiceTest {
                 .region(region1)
                 .build();
 
-            job = Job.builder()
+            job1 = Job.builder()
                 .id(1L)
                 .jobName("요양 보호사")
                 .requiresCertification(Require.REQUIRED)
@@ -126,22 +128,45 @@ public class TodoMemberServiceTest {
                 .certifications(new ArrayList<>())
                 .build();
 
+            job2 = Job.builder()
+                .id(2L)
+                .jobName("심리 상담사")
+                .requiresCertification(Require.REQUIRED)
+                .workTimeSlot(WorkTime.FLEXIBLE)
+                .salaryType(SalaryType.MONTHLY)
+                .salaryCost(2500000)
+                .interpersonalContactLevel(Level.MEDIUM)
+                .physicalActivityLevel(PhysicalActivity.HIGH)
+                .emotionalLaborLevel(Level.HIGH)
+                .jobImageUrl("https://example.com/image.jpg")
+                .ncsName("심리상담서비스")
+                .certifications(new ArrayList<>())
+                .build();
+
             jobTodo = JobTodo.builder()
                 .id(1L)
-                .job(job)
+                .job(job1)
                 .title("test title")
                 .build();
 
-            todoGroup = TodoGroup.builder()
+            todoGroup1 = TodoGroup.builder()
                 .id(1L)
-                .job(job)
+                .job(job1)
+                .member(mockMember)
+                .todo(new ArrayList<>())
+                .totalView((0L))
+                .build();
+
+            todoGroup2 = TodoGroup.builder()
+                .id(2L)
+                .job(job2)
                 .member(mockMember)
                 .todo(new ArrayList<>())
                 .totalView((0L))
                 .build();
 
             todo = Todo.builder()
-                .todoGroup(todoGroup)
+                .todoGroup(todoGroup1)
                 .member(mockMember)
                 .title("testTitle")
                 .memoText("testMemo")
@@ -170,16 +195,16 @@ public class TodoMemberServiceTest {
             when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             when(jobRepository.findById(1L))
-                .thenReturn(Optional.of(job));
+                .thenReturn(Optional.of(job1));
 
-            when(todoGroupRepository.save(any(TodoGroup.class))).thenReturn(todoGroup);
+            when(todoGroupRepository.save(any(TodoGroup.class))).thenReturn(todoGroup1);
 
             AddJobTodoResponseDto responseDto = todoMemberService.addJobToMyList(1L);
 
             assertAll(
-                () -> assertThat(todoGroup).isNotNull(),
-                () -> assertThat(todoGroup.getId()).isEqualTo(responseDto.todoGroupId()),
-                () -> assertThat(todoGroup.getMember().getId()).isEqualTo(responseDto.memberId()),
+                () -> assertThat(todoGroup1).isNotNull(),
+                () -> assertThat(responseDto.todoGroupId()).isEqualTo(1L),
+                () -> assertThat(todoGroup1.getMember().getId()).isEqualTo(responseDto.memberId()),
                 () -> assertThat("직업 담기 완료").isEqualTo(responseDto.message())
             );
         }
@@ -192,16 +217,16 @@ public class TodoMemberServiceTest {
             when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
 
             when(todoGroupRepository.findAllByMember(mockMember))
-                .thenReturn(List.of(todoGroup));
+                .thenReturn(List.of(todoGroup1));
 
             List<GetTodoJobResponseDto> jobs = todoMemberService.getTodoJobList();
 
             assertAll(
-                 () -> assertThat(jobs).isNotNull(),
-                 () -> assertThat(jobs).hasSize(1),
-                 () -> assertThat(jobs.get(0).todoGroupId()).isEqualTo(todoGroup.getId()),
-                 () -> assertThat(jobs.get(0).jobName()).isEqualTo(todoGroup.getJob().getJobName())
-             );
+                () -> assertThat(jobs).isNotNull(),
+                () -> assertThat(jobs).hasSize(1),
+                () -> assertThat(jobs.get(0).todoGroupId()).isEqualTo(todoGroup1.getId()),
+                () -> assertThat(jobs.get(0).jobName()).isEqualTo(todoGroup1.getJob().getJobName())
+            );
         }
     }
 
@@ -209,6 +234,11 @@ public class TodoMemberServiceTest {
     @DisplayName("마이드림")
     class MyDreamTodoTest {
         // 직업 목록 조회
+        @Test
+        @DisplayName("하나의 투두 리스트 조회")
+        void getOneTodoGroup(){
+
+        }
         // 기본 투두 목록 조회
         // 메모 작성
         // 메모 삭제

--- a/src/test/java/com/dodream/todo/application/TodoServiceTest.java
+++ b/src/test/java/com/dodream/todo/application/TodoServiceTest.java
@@ -1,13 +1,40 @@
 package com.dodream.todo.application;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.dodream.core.application.ObjectStorageService;
 import com.dodream.core.infrastructure.security.CustomUserDetails;
+import com.dodream.job.domain.Job;
+import com.dodream.job.domain.JobTodo;
+import com.dodream.job.domain.Level;
+import com.dodream.job.domain.PhysicalActivity;
+import com.dodream.job.domain.Require;
+import com.dodream.job.domain.SalaryType;
+import com.dodream.job.domain.WorkTime;
+import com.dodream.job.repository.JobRepository;
+import com.dodream.job.repository.JobTodoRepository;
+import com.dodream.member.application.MemberAuthService;
+import com.dodream.member.application.MemberService;
 import com.dodream.member.domain.Gender;
 import com.dodream.member.domain.Member;
 import com.dodream.member.domain.State;
 import com.dodream.member.repository.MemberRepository;
 import com.dodream.region.domain.Region;
-import com.dodream.region.repository.RegionRepository;
+import com.dodream.todo.domain.Todo;
+import com.dodream.todo.domain.TodoGroup;
+import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
+import com.dodream.todo.dto.response.GetOneTodoWithMemoResponseDto;
+import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
+import com.dodream.todo.repository.TodoGroupRepository;
+import com.dodream.todo.repository.TodoRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +44,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -29,13 +59,28 @@ public class TodoServiceTest {
     @Mock
     private MemberRepository memberRepository;
     @Mock
-    private RegionRepository regionRepository;
+    private JobRepository jobRepository;
+    @Mock
+    private JobTodoRepository jobTodoRepository;
+    @Mock
+    private TodoGroupRepository todoGroupRepository;
+    @Mock
+    private TodoRepository todoRepository;
     @Mock
     private BCryptPasswordEncoder passwordEncoder;
+    @Mock
+    private ObjectStorageService objectStorageService;
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private MemberAuthService memberAuthService;
+    @Mock
+    private TodoMemberService todoMemberService;
     @InjectMocks
     private TodoService todoService;
 
     private static final Long TEST_ID = 1L;
+    private static final Long OTHER_MEMBER_ID = 2L;
     private static final String TEST_LOGIN_ID = "dodream";
     private static final String TEST_PASSWORD = "password";
     private static final String TEST_NICKNAME = "nickname";
@@ -45,11 +90,20 @@ public class TodoServiceTest {
     private static final String TEST_REGION_CODE1 = "11110";
     private static final String TEST_REGION_NAME1 = "서울 종로구";
     private Member mockMember;
+    private Member otherMember;
     private Region region1;
+    private Job job1;
+    private Job job2;
+    private JobTodo jobTodo;
+    private TodoGroup todoGroup1;
+    private TodoGroup other_todoGroup;
+    private Todo todo1;
+    private Todo todo2;
+    private Todo other_todo;
 
 
     @Nested
-    @DisplayName("홈화면")
+    @DisplayName("타유저 투두")
     class HomeTodoTest {
 
         @BeforeEach
@@ -73,6 +127,95 @@ public class TodoServiceTest {
                 .region(region1)
                 .build();
 
+            otherMember = Member.builder()
+                .id(OTHER_MEMBER_ID)
+                .loginId("other_member_id")
+                .password(passwordEncoder.encode(TEST_PASSWORD))
+                .nickName("other_nickname")
+                .birthDate(TEST_BIRTHDATE)
+                .gender(TEST_GENDER)
+                .state(TEST_STATE)
+                .region(region1)
+                .build();
+
+            job1 = Job.builder()
+                .id(1L)
+                .jobName("요양 보호사")
+                .requiresCertification(Require.REQUIRED)
+                .workTimeSlot(WorkTime.FLEXIBLE)
+                .salaryType(SalaryType.MONTHLY)
+                .salaryCost(2500000)
+                .interpersonalContactLevel(Level.MEDIUM)
+                .physicalActivityLevel(PhysicalActivity.HIGH)
+                .emotionalLaborLevel(Level.HIGH)
+                .jobImageUrl("https://example.com/image.jpg")
+                .ncsName("노인복지서비스")
+                .certifications(new ArrayList<>())
+                .build();
+
+            job2 = Job.builder()
+                .id(2L)
+                .jobName("심리 상담사")
+                .requiresCertification(Require.REQUIRED)
+                .workTimeSlot(WorkTime.FLEXIBLE)
+                .salaryType(SalaryType.MONTHLY)
+                .salaryCost(2500000)
+                .interpersonalContactLevel(Level.MEDIUM)
+                .physicalActivityLevel(PhysicalActivity.HIGH)
+                .emotionalLaborLevel(Level.HIGH)
+                .jobImageUrl("https://example.com/image.jpg")
+                .ncsName("심리상담서비스")
+                .certifications(new ArrayList<>())
+                .build();
+
+            jobTodo = JobTodo.builder()
+                .id(1L)
+                .job(job1)
+                .title("test title")
+                .build();
+
+            todoGroup1 = TodoGroup.builder()
+                .id(1L)
+                .job(job1)
+                .member(mockMember)
+                .todo(new ArrayList<>())
+                .totalView((0L))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+            other_todoGroup = TodoGroup.builder()
+                .id(2L)
+                .job(job1)
+                .member(otherMember)
+                .todo(new ArrayList<>())
+                .totalView(0L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+            todo1 = Todo.builder()
+                .todoGroup(todoGroup1)
+                .member(mockMember)
+                .title("title")
+                .memoText("text")
+                .isPublic(true)
+                .build();
+
+            todo2 = Todo.builder()
+                .todoGroup(todoGroup1)
+                .member(mockMember)
+                .title("title")
+                .memoText("text")
+                .isPublic(true)
+                .build();
+
+            other_todo = Todo.builder()
+                .todoGroup(todoGroup1)
+                .member(mockMember)
+                .title("other_title")
+                .memoText("other_text")
+                .isPublic(true)
+                .build();
+
             CustomUserDetails userDetails = new CustomUserDetails(mockMember);
 
             Authentication authentication = new UsernamePasswordAuthenticationToken(
@@ -89,14 +232,26 @@ public class TodoServiceTest {
         }
 
         @Test
-        @DisplayName("타유저 목록 조회 (3개씩)")
-        void getOtherTodoAtHome() {
-
-        }
-
-        @Test
         @DisplayName("타유저 투두 그룹 조회")
         void getOtherOneTodoGroup() {
+
+            // given
+            when(todoGroupRepository.findTop3ByTotalView(any(Pageable.class)))
+                .thenReturn(List.of(todoGroup1));
+            when(todoRepository.findTop2ByTodoGroup(any(), any()))
+                .thenReturn(List.of(todo1, todo2));
+            when(todoRepository.countByTodoGroup(any()))
+                .thenReturn(1L);
+
+            // when
+            List<GetOthersTodoGroupResponseDto> result = todoService.getOneTodoGroupPublicAtHome();
+
+            // then
+            assertEquals(1, result.size());
+            for (GetOthersTodoGroupResponseDto dto : result) {
+                assertEquals(2, dto.todos().size());
+                assertEquals(1L, dto.todoCount());
+            }
 
         }
 
@@ -104,22 +259,94 @@ public class TodoServiceTest {
         @DisplayName("타유저 투두 메모 조회")
         void getOtherOneTodo() {
 
+            // given
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
+            when(jobRepository.findById(1L)).thenReturn(Optional.of(job1));
+            when(todoGroupRepository.findTop3ByJobAndNotMember(eq(job1), eq(mockMember), any()))
+                .thenReturn(List.of(other_todoGroup));
+            when(todoRepository.findTop2ByTodoGroup(eq(other_todoGroup), any()))
+                .thenReturn(List.of(other_todo));
+            when(todoRepository.countByTodoGroup(any())).thenReturn(1L);
+
+            // when
+            List<GetOthersTodoGroupResponseDto> result = todoService.getOthersTodoSimple(1L);
+
+            // then
+            assertEquals(1, result.size());
+            for (GetOthersTodoGroupResponseDto dto : result) {
+                assertEquals(1, dto.todos().size());
+                assertEquals(1L, dto.todoCount());
+            }
+
         }
 
         @Test
         @DisplayName("특정 직업 타유저 투두 그룹 목록 조회")
         void getOneJobOtherOneTodoGroupList() {
 
+            // given
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
+            when(jobRepository.findById(1L)).thenReturn(Optional.of(job1));
+
+            Page<TodoGroup> todoGroupPage = new PageImpl<>(List.of(todoGroup1));
+            when(todoGroupRepository.findTop10ByJobAndNotMember(eq(job1), eq(mockMember), any()))
+                .thenReturn(todoGroupPage);
+
+            when(todoRepository.findTop3ByTodoGroup(any(), any()))
+                .thenReturn(List.of(other_todo));
+
+            when(todoRepository.countByTodoGroup(any())).thenReturn(1L);
+
+            // when
+            Page<GetOthersTodoGroupResponseDto> result = todoService.getOthersTodoByJob(1L, 0);
+
+            // then
+            assertEquals(1, result.getContent().size());
+            for (GetOthersTodoGroupResponseDto dto : result.getContent()) {
+                assertEquals(1, dto.todos().size());
+                assertEquals(1L, dto.todoCount());
+            }
+            assertEquals(0, result.getNumber());
+            assertEquals(1, result.getTotalElements());
+
         }
 
         @Test
-        @DisplayName("특정 직업 타유저 투두 그룹 목록 조회")
-        void getSimpleOneJobOtherOneTodoGroupList() {
+        @DisplayName("타유저 투두 리스트 상세 조회")
+        void getOtherOneTodoGroupList() {
+
+            // given
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
+            when(todoGroupRepository.findByIdAndMemberNot(2L, mockMember))
+                .thenReturn(Optional.of(other_todoGroup));
+
+            // when
+            GetOneTodoGroupResponseDto result = todoService.getOneOthersTodoGroup(2L);
+
+            //then
+            assertEquals(other_todoGroup.getId(), result.todoGroupId());
+            assertEquals(otherMember.getNickName(), result.memberNickname());
+            assertEquals(other_todoGroup.getJob().getJobName(), result.jobName());
 
         }
 
+        @Test
+        @DisplayName("타유저 투두 메모 상세 조회")
+        void getOtherOneTodoMemo() {
 
+            // given
+            when(memberAuthService.getCurrentMember()).thenReturn(mockMember);
+            when(todoRepository.findByIdAndMemberNot(2L, mockMember))
+                .thenReturn(Optional.of(other_todo));
+
+            // when
+            GetOneTodoWithMemoResponseDto result = todoService.getOneOthersTodoMemo(2L);
+
+            //then
+            assertEquals(other_todo.getTitle(), result.title());
+            assertEquals(other_todo.getIsPublic(), result.isPublic());
+            assertEquals(other_todo.getMemoText(), result.memoText());
+
+        }
     }
-
-
 }

--- a/src/test/java/com/dodream/todo/application/TodoServiceTest.java
+++ b/src/test/java/com/dodream/todo/application/TodoServiceTest.java
@@ -45,9 +45,6 @@ public class TodoServiceTest {
     private static final String TEST_REGION_CODE1 = "11110";
     private static final String TEST_REGION_NAME1 = "서울 종로구";
     private Member mockMember;
-    private Member other1;
-    private Member other2;
-    private Member other3;
     private Region region1;
 
 

--- a/src/test/java/com/dodream/todo/application/TodoServiceTest.java
+++ b/src/test/java/com/dodream/todo/application/TodoServiceTest.java
@@ -1,0 +1,128 @@
+package com.dodream.todo.application;
+
+import com.dodream.core.infrastructure.security.CustomUserDetails;
+import com.dodream.member.domain.Gender;
+import com.dodream.member.domain.Member;
+import com.dodream.member.domain.State;
+import com.dodream.member.repository.MemberRepository;
+import com.dodream.region.domain.Region;
+import com.dodream.region.repository.RegionRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class TodoServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private RegionRepository regionRepository;
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+    @InjectMocks
+    private TodoService todoService;
+
+    private static final Long TEST_ID = 1L;
+    private static final String TEST_LOGIN_ID = "dodream";
+    private static final String TEST_PASSWORD = "password";
+    private static final String TEST_NICKNAME = "nickname";
+    private static final LocalDate TEST_BIRTHDATE = LocalDate.of(2000, 1, 1);
+    private static final Gender TEST_GENDER = Gender.FEMALE;
+    private static final State TEST_STATE = State.ACTIVE;
+    private static final String TEST_REGION_CODE1 = "11110";
+    private static final String TEST_REGION_NAME1 = "서울 종로구";
+    private Member mockMember;
+    private Member other1;
+    private Member other2;
+    private Member other3;
+    private Region region1;
+
+
+    @Nested
+    @DisplayName("홈화면")
+    class HomeTodoTest {
+
+        @BeforeEach
+        void setupSecurityContext() {
+
+            //given
+            region1 = Region.builder()
+                .id(1L)
+                .regionCode(TEST_REGION_CODE1)
+                .regionName(TEST_REGION_NAME1)
+                .build();
+
+            mockMember = Member.builder()
+                .id(TEST_ID)
+                .loginId(TEST_LOGIN_ID)
+                .password(passwordEncoder.encode(TEST_PASSWORD))
+                .nickName(TEST_NICKNAME)
+                .birthDate(TEST_BIRTHDATE)
+                .gender(TEST_GENDER)
+                .state(TEST_STATE)
+                .region(region1)
+                .build();
+
+            CustomUserDetails userDetails = new CustomUserDetails(mockMember);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities());
+
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+        }
+
+        @AfterEach
+        void clearSecurityContext() {
+            SecurityContextHolder.clearContext();
+        }
+
+        @Test
+        @DisplayName("타유저 목록 조회 (3개씩)")
+        void getOtherTodoAtHome() {
+
+        }
+
+        @Test
+        @DisplayName("타유저 투두 그룹 조회")
+        void getOtherOneTodoGroup() {
+
+        }
+
+        @Test
+        @DisplayName("타유저 투두 메모 조회")
+        void getOtherOneTodo() {
+
+        }
+
+        @Test
+        @DisplayName("특정 직업 타유저 투두 그룹 목록 조회")
+        void getOneJobOtherOneTodoGroupList() {
+
+        }
+
+        @Test
+        @DisplayName("특정 직업 타유저 투두 그룹 목록 조회")
+        void getSimpleOneJobOtherOneTodoGroupList() {
+
+        }
+
+
+    }
+
+
+}


### PR DESCRIPTION
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 투두 api를 검토
- 투두 클래스 테스트 코드를 작성
- 투두의 images => NPE방지 위해 @Builder.Default 설정 추가

## ✏️ 관련 이슈
#160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
    - TodoMemberService의 멤버 투두 및 직업 관리 기능에 대한 단위 테스트가 추가되었습니다.
    - TodoService의 타인 공개 투두 그룹 및 투두 조회 기능에 대한 단위 테스트가 추가되었습니다.
    - MemberService의 테스트에서 멤버 인증 서비스 모킹 방식이 개선되었습니다.

- **버그 수정**
    - Todo 엔티티에서 빌더 패턴 사용 시 images 리스트가 기본값으로 빈 리스트로 초기화되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->