### PR TITLE
Feat(#232) 이메일 인증 이후 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/dodream/member/dto/request/ChangeMemberPasswordByEmailRequestDto.java
+++ b/src/main/java/com/dodream/member/dto/request/ChangeMemberPasswordByEmailRequestDto.java
@@ -1,0 +1,22 @@
+package com.dodream.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangeMemberPasswordByEmailRequestDto(
+
+        @NotBlank(message = "이메일을 입력해주세요")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
+        @Schema(description = "비밀번호 변경할려는 회원 이메일", example = "test1@dodream.com")
+        String email,
+
+        @NotBlank
+        @Schema(description = "비밀번호 변경할 회원 아이디", example = "test1")
+        String loginId,
+
+        @NotBlank
+        @Schema(description = "새로운 비밀번호", example = "new_password")
+        String newPassword
+) {
+}

--- a/src/main/java/com/dodream/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/dodream/member/exception/MemberErrorCode.java
@@ -21,6 +21,7 @@ public enum MemberErrorCode implements BaseErrorCode<DomainException> {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 문제가 발생했습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제 중 문제가 발생했습니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+    DUPLICATED_PASSWORD(HttpStatus.CONFLICT, "이전과 동일한 비밀번호입니다."),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 이메일이 존재하지 않습니다."),
     EMAIL_AND_LOGINID_NOT_FOUND(HttpStatus.NOT_FOUND, "이메일과 아이디가 일치하지 않습니다."),
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 정보가 존재하지 않습니다."),

--- a/src/main/java/com/dodream/member/presentation/controller/MemberVerificationEmailController.java
+++ b/src/main/java/com/dodream/member/presentation/controller/MemberVerificationEmailController.java
@@ -1,8 +1,8 @@
 package com.dodream.member.presentation.controller;
 
 import com.dodream.core.presentation.RestResponse;
-import com.dodream.core.util.email.value.VerificationType;
 import com.dodream.member.application.MemberVerificationEmailService;
+import com.dodream.member.dto.request.ChangeMemberPasswordByEmailRequestDto;
 import com.dodream.member.dto.request.EmailVerificationRequestDto;
 import com.dodream.member.dto.request.VerificationEmailRequestDto;
 import com.dodream.member.dto.response.EmailVerificationResponseDto;
@@ -51,5 +51,17 @@ public class MemberVerificationEmailController implements MemberVerificationEmai
         ));
     }
 
-
+    @Override
+    @PostMapping("/password")
+    public ResponseEntity<RestResponse<Boolean>> changePassword(
+            @Valid @RequestBody ChangeMemberPasswordByEmailRequestDto changeMemberPasswordByEmailRequestDto
+    ){
+        return ResponseEntity.ok(new RestResponse<>(
+                memberVerificationEmailService.updatePassword(
+                        changeMemberPasswordByEmailRequestDto.email(),
+                        changeMemberPasswordByEmailRequestDto.loginId(),
+                        changeMemberPasswordByEmailRequestDto.newPassword()
+                )
+        ));
+    }
 }

--- a/src/main/java/com/dodream/member/presentation/swagger/MemberVerificationEmailSwagger.java
+++ b/src/main/java/com/dodream/member/presentation/swagger/MemberVerificationEmailSwagger.java
@@ -1,6 +1,7 @@
 package com.dodream.member.presentation.swagger;
 
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.member.dto.request.ChangeMemberPasswordByEmailRequestDto;
 import com.dodream.member.dto.request.EmailVerificationRequestDto;
 import com.dodream.member.dto.request.VerificationEmailRequestDto;
 import com.dodream.member.dto.response.EmailVerificationResponseDto;
@@ -32,5 +33,14 @@ public interface MemberVerificationEmailSwagger {
     )
     ResponseEntity<RestResponse<EmailVerificationResponseDto>> sendVerificationEmail(
             @Valid @RequestBody EmailVerificationRequestDto verificationEmailRequestDto
+    );
+
+    @Operation(
+            summary = "이메일 인증 후 비밀번호 변경 api",
+            description = "이메일 인증 이후 비밀번호를 변경할 때 사용하는 API",
+            operationId = "/v1/member/auth/email/password"
+    )
+    ResponseEntity<RestResponse<Boolean>> changePassword(
+            @Valid @RequestBody ChangeMemberPasswordByEmailRequestDto changeMemberPasswordByEmailRequestDto
     );
 }

--- a/src/main/java/com/dodream/member/repository/MemberRepository.java
+++ b/src/main/java/com/dodream/member/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.dodream.member.repository;
 import com.dodream.member.domain.Member;
 import com.dodream.member.domain.State;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -15,6 +16,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginIdAndState(String loginId, State state);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmailAndLoginId(String email, String loginId);
 
     boolean existsByEmailAndState(String email, State state);
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
 이메일 인증 이후 비밀번호 변경 API 구현
## ✏️ 관련 이슈
#232 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이메일 인증 후 비밀번호 변경 기능이 추가되었습니다. 사용자는 이메일, 로그인 ID, 새 비밀번호를 입력하여 비밀번호를 변경할 수 있습니다.
* **버그 수정**
  * 일부 디버그 메시지가 제거되어 서비스 안정성이 향상되었습니다.
* **문서화**
  * 비밀번호 변경 API가 Swagger 문서에 추가되어 개발자 및 사용자에게 안내가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->