### PR TITLE
Fix(#241) : 이메일 연속 인증시 인증 메일이 도착하지 않는 오류를 수정한다.

### DIFF
--- a/src/main/java/com/dodream/core/util/email/EmailUtil.java
+++ b/src/main/java/com/dodream/core/util/email/EmailUtil.java
@@ -6,6 +6,7 @@ import com.dodream.core.util.email.factory.VerificationEmailFactory;
 import com.dodream.core.util.email.value.VerificationType;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -15,6 +16,7 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Component
 @RequiredArgsConstructor
+@Log4j2
 public class EmailUtil {
 
     private final JavaMailSender mailSender;

--- a/src/main/java/com/dodream/member/application/MemberVerificationEmailService.java
+++ b/src/main/java/com/dodream/member/application/MemberVerificationEmailService.java
@@ -70,7 +70,7 @@ public class MemberVerificationEmailService {
 
         String cacheKey = generateCacheKey(email, type);
 
-        String cachedCode = (String) redisTemplate.opsForValue().get(cacheKey);
+        String cachedCode = (String) redisTemplate.opsForValue().getAndDelete(cacheKey);
 
         if (cachedCode == null) {
             throw MemberErrorCode.VERIFICATION_NOT_FOUND.toException();


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
- 이메일 연속 인증시 인증메일이 도착하지 않는 오류 수정 
   - 인증코드 재사용시 getAndDelete()로 변경 
## ✏️ 관련 이슈
#241 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 이메일 인증 시, 인증 코드가 한 번 사용된 후 즉시 삭제되어 재사용이 불가능하도록 개선되었습니다.

* **기타**
  * 이메일 유틸리티 클래스에 로깅 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->