### PR TITLE
Feat(#249) : 회원 레벨 조회, 설정 api를 구현한다.

### DIFF
--- a/src/main/java/com/dodream/member/application/MemberService.java
+++ b/src/main/java/com/dodream/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.dodream.member.application;
 
 import com.dodream.core.application.ObjectStorageService;
+import com.dodream.member.domain.Level;
 import com.dodream.member.domain.Member;
 import com.dodream.member.domain.State;
 import com.dodream.member.dto.request.ChangeMemberBirthDateRequestDto;
@@ -13,6 +14,8 @@ import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
 import com.dodream.member.dto.response.DeleteMemberProfileImageResponseDto;
 import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.GetMemberInterestedJobResponseDto;
+import com.dodream.member.dto.response.GetMemberLevelInfoResponseDto;
+import com.dodream.member.dto.response.PostMemberLevelResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.exception.MemberErrorCode;
 import com.dodream.member.repository.MemberRepository;
@@ -21,6 +24,8 @@ import com.dodream.region.exception.RegionErrorCode;
 import com.dodream.region.repository.RegionRepository;
 import com.dodream.todo.domain.TodoGroup;
 import com.dodream.todo.repository.TodoGroupRepository;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -159,4 +164,22 @@ public class MemberService {
 
         return jobResponseDto;
     }
+
+    @Transactional(readOnly = true)
+    public List<GetMemberLevelInfoResponseDto> getMemberLevelList() {
+
+        return Arrays.stream(Level.values())
+            .map(GetMemberLevelInfoResponseDto::from)
+            .toList();
+    }
+
+    @Transactional
+    public PostMemberLevelResponseDto postMemberLevel(Level level) {
+
+        Member member = memberAuthService.getCurrentMember();
+        member.updateLevel(level);
+
+        return PostMemberLevelResponseDto.of(member.getId(), level);
+    }
+
 }

--- a/src/main/java/com/dodream/member/domain/Level.java
+++ b/src/main/java/com/dodream/member/domain/Level.java
@@ -1,0 +1,16 @@
+package com.dodream.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Level {
+
+    SEED("씨앗","관심은 있지만, 아직 정보만 찾아보고 있어요"),
+    SPROUT("새쌋","교육을 듣거나, 자격증 공부를 시작할거예요."),
+    TREE("꿈나무","실제로 채용 공고를 찾거나, 서류를 준비하고 있어요.");
+
+    private final String value;
+    private final String description;
+}

--- a/src/main/java/com/dodream/member/domain/Level.java
+++ b/src/main/java/com/dodream/member/domain/Level.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum Level {
 
     SEED("씨앗","관심은 있지만, 아직 정보만 찾아보고 있어요"),
-    SPROUT("새쌋","교육을 듣거나, 자격증 공부를 시작할거예요."),
+    SPROUT("새싹","교육을 듣거나, 자격증 공부를 시작할거예요."),
     TREE("꿈나무","실제로 채용 공고를 찾거나, 서류를 준비하고 있어요.");
 
     private final String value;

--- a/src/main/java/com/dodream/member/domain/Member.java
+++ b/src/main/java/com/dodream/member/domain/Member.java
@@ -68,6 +68,11 @@ public class Member extends BaseLongIdEntity {
     @Builder.Default
     private State state = State.ACTIVE;
 
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    private Level level;
+
+
     public void updateProfile(String imageUrl) {
         this.profileImage = imageUrl;
     }
@@ -87,5 +92,7 @@ public class Member extends BaseLongIdEntity {
     public void updateBirthDate(LocalDate birthDate) {
         this.birthDate = birthDate;
     }
+
+    public void updateLevel(Level level){ this.level = level; }
 
 }

--- a/src/main/java/com/dodream/member/dto/response/GetMemberInfoResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/GetMemberInfoResponseDto.java
@@ -4,7 +4,6 @@ import com.dodream.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -24,7 +23,9 @@ public record GetMemberInfoResponseDto(
     @Schema(description = "거주지", example = "서울시 강동구")
     String regionName,
     @Schema(description = "관심 직업")
-    GetMemberInterestedJobResponseDto job
+    GetMemberInterestedJobResponseDto job,
+    @Schema(description = "레벨")
+    String level
 ) {
 
     public static GetMemberInfoResponseDto of(Member member,
@@ -37,8 +38,7 @@ public record GetMemberInfoResponseDto(
             .birthDate(member.getBirthDate())
             .regionName(member.getRegion().getRegionName())
             .job(job)
+            .level(member.getLevel() != null ? member.getLevel().getValue() : null)
             .build();
-
     }
-
 }

--- a/src/main/java/com/dodream/member/dto/response/GetMemberLevelInfoResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/GetMemberLevelInfoResponseDto.java
@@ -1,0 +1,22 @@
+package com.dodream.member.dto.response;
+
+import com.dodream.member.domain.Level;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetMemberLevelInfoResponseDto(
+    @Schema(description = "레벨", example = "SEED")
+    Level code,
+
+    @Schema(description = "레벨 한글명", example = "새싹")
+    String value,
+
+    @Schema(description = "레벨 설명", example = "관심만 있고, 아직 시작은 안했어요")
+    String description
+
+) {
+
+    public static GetMemberLevelInfoResponseDto from(Level level) {
+        return new GetMemberLevelInfoResponseDto(level, level.getValue(), level.getDescription());
+    }
+
+}

--- a/src/main/java/com/dodream/member/dto/response/PostMemberLevelResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/PostMemberLevelResponseDto.java
@@ -8,7 +8,7 @@ public record PostMemberLevelResponseDto(
     @Schema(description = "멤버 id(DB상)", example = "1")
     Long memberId,
 
-    @Schema(description = "새싹", example = "멤버 단계")
+    @Schema(description = "멤버 단계", example = "새싹")
     String level,
 
     @Schema(description = "메세지", example = "멤버 단계 설정 완료")

--- a/src/main/java/com/dodream/member/dto/response/PostMemberLevelResponseDto.java
+++ b/src/main/java/com/dodream/member/dto/response/PostMemberLevelResponseDto.java
@@ -1,0 +1,22 @@
+package com.dodream.member.dto.response;
+
+import com.dodream.member.domain.Level;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PostMemberLevelResponseDto(
+
+    @Schema(description = "멤버 id(DB상)", example = "1")
+    Long memberId,
+
+    @Schema(description = "새싹", example = "멤버 단계")
+    String level,
+
+    @Schema(description = "메세지", example = "멤버 단계 설정 완료")
+    String message
+
+) {
+    public static PostMemberLevelResponseDto of(Long memberId, Level level) {
+          return new PostMemberLevelResponseDto(memberId, level.getValue() , "멤버 단계 설정 완료");
+      }
+
+}

--- a/src/main/java/com/dodream/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/dodream/member/presentation/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.dodream.member.presentation.controller;
 
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.member.application.MemberService;
+import com.dodream.member.domain.Level;
 import com.dodream.member.dto.request.ChangeMemberBirthDateRequestDto;
 import com.dodream.member.dto.request.ChangeMemberNickNameRequestDto;
 import com.dodream.member.dto.request.ChangeMemberPasswordRequestDto;
@@ -12,10 +13,13 @@ import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
 import com.dodream.member.dto.response.DeleteMemberProfileImageResponseDto;
 import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.GetMemberInterestedJobResponseDto;
+import com.dodream.member.dto.response.GetMemberLevelInfoResponseDto;
+import com.dodream.member.dto.response.PostMemberLevelResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.presentation.swagger.MemberSwagger;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -103,5 +107,18 @@ public class MemberController implements MemberSwagger {
             new RestResponse<>(memberService.getMemberJob()));
     }
 
+    @Override
+    @GetMapping("/level")
+    public ResponseEntity<RestResponse<List<GetMemberLevelInfoResponseDto>>> getMemberLevelList() {
+        return ResponseEntity.ok(
+            new RestResponse<>(memberService.getMemberLevelList()));
+    }
+
+    @Override
+    @PostMapping("/level")
+    public ResponseEntity<RestResponse<PostMemberLevelResponseDto>> postMemberLevel(@RequestParam(name = "level") Level level) {
+        return ResponseEntity.ok(
+            new RestResponse<>(memberService.postMemberLevel(level)));
+    }
 
 }

--- a/src/main/java/com/dodream/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/dodream/member/presentation/controller/MemberController.java
@@ -108,7 +108,7 @@ public class MemberController implements MemberSwagger {
     }
 
     @Override
-    @GetMapping("/level")
+    @GetMapping("/level/all")
     public ResponseEntity<RestResponse<List<GetMemberLevelInfoResponseDto>>> getMemberLevelList() {
         return ResponseEntity.ok(
             new RestResponse<>(memberService.getMemberLevelList()));

--- a/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
+++ b/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
@@ -2,6 +2,7 @@ package com.dodream.member.presentation.swagger;
 
 import com.dodream.core.config.swagger.ApiErrorCode;
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.member.domain.Level;
 import com.dodream.member.dto.request.ChangeMemberBirthDateRequestDto;
 import com.dodream.member.dto.request.ChangeMemberNickNameRequestDto;
 import com.dodream.member.dto.request.ChangeMemberPasswordRequestDto;
@@ -12,11 +13,14 @@ import com.dodream.member.dto.response.ChangeMemberRegionResponseDto;
 import com.dodream.member.dto.response.DeleteMemberProfileImageResponseDto;
 import com.dodream.member.dto.response.GetMemberInfoResponseDto;
 import com.dodream.member.dto.response.GetMemberInterestedJobResponseDto;
+import com.dodream.member.dto.response.GetMemberLevelInfoResponseDto;
+import com.dodream.member.dto.response.PostMemberLevelResponseDto;
 import com.dodream.member.dto.response.UploadMemberProfileImageResponseDto;
 import com.dodream.member.exception.MemberErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -94,5 +98,22 @@ public interface MemberSwagger {
     )
     @ApiErrorCode(MemberErrorCode.class)
     ResponseEntity<RestResponse<GetMemberInterestedJobResponseDto>> getMemberJob();
+
+    @Operation(
+        summary = "멤버 레벨 리스트 조회 API",
+        description = "멤버의 레벨 리스트를 조회한다.",
+        operationId = "/v1/member/level"
+    )
+    @ApiErrorCode(MemberErrorCode.class)
+    ResponseEntity<RestResponse<List<GetMemberLevelInfoResponseDto>>> getMemberLevelList();
+
+    @Operation(
+        summary = "멤버 레벨 설정 API",
+        description = "멤버의 레벨을 설정한다.",
+        operationId = "/v1/member/level"
+    )
+    @ApiErrorCode(MemberErrorCode.class)
+    ResponseEntity<RestResponse<PostMemberLevelResponseDto>> postMemberLevel(
+        @RequestParam(name = "level") Level level);
 
 }

--- a/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
+++ b/src/main/java/com/dodream/member/presentation/swagger/MemberSwagger.java
@@ -102,7 +102,7 @@ public interface MemberSwagger {
     @Operation(
         summary = "멤버 레벨 리스트 조회 API",
         description = "멤버의 레벨 리스트를 조회한다.",
-        operationId = "/v1/member/level"
+        operationId = "/v1/member/level/all"
     )
     @ApiErrorCode(MemberErrorCode.class)
     ResponseEntity<RestResponse<List<GetMemberLevelInfoResponseDto>>> getMemberLevelList();


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

- level enum 클래스 정의
- 회원 레벨리스트 조회 api를 구현
- 회원 레벨 설정 api 구현 (초기 설정, 수정)
- 자신의 레벨 조회 api 구현

## ✏️ 관련 이슈
#249 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 멤버 단계 조회 기능 추가: 모든 멤버 단계 목록(코드, 표시값, 설명) 제공
  - 멤버 단계 설정 기능 추가: 현재 사용자 멤버 단계를 선택해 저장하고 결과 메시지 반환
  - 새로운 API 엔드포인트 제공: /v1/member/level (GET: 목록 조회, POST: 단계 설정)

- 문서
  - 위 엔드포인트에 대한 API 스펙 및 예시 응답을 스웨거 문서에 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->