### PR TITLE
Feat(#251) :  직업별 단계별 투두 리스트 조회 api를 구현하다.

### DIFF
--- a/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
@@ -35,7 +35,8 @@ public class SecurityConfiguration {
         "/v1/member/auth/email/**",
         "/v1/clova/**",
         "/v1/job/**",
-        "/v1/todo/other/public"
+        "/v1/todo/other/public",
+        "/v1/job/todo/**"
     };
 
     @Bean

--- a/src/main/java/com/dodream/job/application/JobService.java
+++ b/src/main/java/com/dodream/job/application/JobService.java
@@ -1,13 +1,18 @@
 package com.dodream.job.application;
 
 import com.dodream.job.domain.Job;
+import com.dodream.job.domain.JobTodo;
+import com.dodream.job.domain.TodoCategory;
 import com.dodream.job.dto.response.JobAddListDto;
 import com.dodream.job.dto.response.JobListDto;
 import com.dodream.job.dto.response.JobResponseDto;
+import com.dodream.job.dto.response.JobTodoListResponseDto;
+import com.dodream.job.dto.response.JobTodoResponseDto;
 import com.dodream.job.exception.JobErrorCode;
 import com.dodream.job.infrastructure.JobImageUrlGenerator;
 import com.dodream.job.repository.JobRepository;
 import com.dodream.job.repository.JobSpecification;
+import com.dodream.job.repository.JobTodoRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,17 +28,19 @@ public class JobService {
 
     private final JobRepository jobRepository;
     private final JobImageUrlGenerator imageUrlGenerator;
+    private final JobTodoRepository jobTodoRepository;
 
     public JobResponseDto getJobById(Long id) {
         Job job = jobRepository.findById(id).orElseThrow(
-                JobErrorCode.CANNOT_GET_JOB_DATA::toException
+            JobErrorCode.CANNOT_GET_JOB_DATA::toException
         );
 
         return JobResponseDto.from(job);
     }
 
-    public Page<JobListDto> getAllJobs(int pageNumber, String require, String workTime, String physical) {
-        if(pageNumber < 0) {
+    public Page<JobListDto> getAllJobs(int pageNumber, String require, String workTime,
+        String physical) {
+        if (pageNumber < 0) {
             pageNumber = 0;
         }
 
@@ -44,10 +51,25 @@ public class JobService {
         return jobs.map(job -> JobListDto.from(job, imageUrlGenerator));
     }
 
-    public List<JobAddListDto> getAddJobList(){
+    public List<JobAddListDto> getAddJobList() {
         return jobRepository.findAll()
             .stream()
-            .map(job -> JobAddListDto.from(job,imageUrlGenerator))
+            .map(job -> JobAddListDto.from(job, imageUrlGenerator))
             .toList();
+    }
+
+    public JobTodoListResponseDto getJodTodoList(Long id, TodoCategory todoCategory) {
+
+        Job job = jobRepository.findById(id).orElseThrow(
+            JobErrorCode.CANNOT_GET_JOB_DATA::toException
+        );
+
+        List<JobTodoResponseDto> jobTodos = jobTodoRepository.findByJobAndTodoCategory(job,
+                todoCategory).stream()
+            .map(JobTodoResponseDto::from)
+            .toList();
+
+        return JobTodoListResponseDto.of(job,jobTodos,todoCategory);
+
     }
 }

--- a/src/main/java/com/dodream/job/domain/JobTodo.java
+++ b/src/main/java/com/dodream/job/domain/JobTodo.java
@@ -6,9 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -17,8 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Entity
 @Getter
@@ -31,6 +26,11 @@ public class JobTodo extends BaseLongIdEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_id")
     private Job job;
+
+    @Column(name = "todo_category")
+//    @Column(nullable = false, name = "todo_category")
+    @Enumerated(EnumType.STRING)
+    private TodoCategory todoCategory;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/com/dodream/job/dto/response/JobTodoListResponseDto.java
+++ b/src/main/java/com/dodream/job/dto/response/JobTodoListResponseDto.java
@@ -1,0 +1,26 @@
+package com.dodream.job.dto.response;
+
+import com.dodream.job.domain.Job;
+import com.dodream.job.domain.TodoCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record JobTodoListResponseDto(
+    @Schema(name = "직업 DB 식별자", example = "1")
+    Long jobId,
+
+    @Schema(name = "직업 이름", example = "요양보호사")
+    String jobName,
+
+    @Schema(name = "투두 카테고리", example = "준비하기")
+    String todoCategory,
+
+    @Schema(name = "직업 투두 목록")
+    List<JobTodoResponseDto> jobTodos
+
+) {
+
+    public static JobTodoListResponseDto of(Job job, List<JobTodoResponseDto> jobTodos, TodoCategory todoCategory) {
+        return new JobTodoListResponseDto(job.getId(), job.getJobName(), todoCategory.getValue(), jobTodos);
+    }
+}

--- a/src/main/java/com/dodream/job/dto/response/JobTodoResponseDto.java
+++ b/src/main/java/com/dodream/job/dto/response/JobTodoResponseDto.java
@@ -1,0 +1,17 @@
+package com.dodream.job.dto.response;
+
+import com.dodream.job.domain.JobTodo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record JobTodoResponseDto(
+    @Schema(name = "JobTodo id", example = "5")
+    Long JobTodoId,
+    @Schema(name = "JobTodo 내용", example = "요양 보호사에 대한 자격증 준비하기")
+    String title
+
+) {
+
+    public static JobTodoResponseDto from(JobTodo jobTodo) {
+        return new JobTodoResponseDto(jobTodo.getId(), jobTodo.getTitle());
+    }
+}

--- a/src/main/java/com/dodream/job/presentation/controller/JobController.java
+++ b/src/main/java/com/dodream/job/presentation/controller/JobController.java
@@ -4,6 +4,9 @@ import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.job.application.JobRecommendService;
 import com.dodream.job.application.JobService;
+import com.dodream.job.domain.TodoCategory;
+import com.dodream.job.dto.response.JobTodoListResponseDto;
+import com.dodream.job.dto.response.JobTodoResponseDto;
 import com.dodream.job.presentation.swagger.JobSwagger;
 import com.dodream.job.dto.request.recommend.OnboardingAnswerSet;
 import com.dodream.job.dto.response.JobAddListDto;
@@ -84,5 +87,13 @@ public class JobController implements JobSwagger {
                 jobService.getAddJobList()
             )
         );
+    }
+
+    @Override
+    @GetMapping("/todo")
+    public ResponseEntity<RestResponse<JobTodoListResponseDto>> getJobTodoList(
+        @RequestParam("id") Long id,
+        @RequestParam("todoCategory") TodoCategory todoCategory) {
+        return ResponseEntity.ok(new RestResponse<>(jobService.getJodTodoList(id, todoCategory)));
     }
 }

--- a/src/main/java/com/dodream/job/presentation/swagger/JobSwagger.java
+++ b/src/main/java/com/dodream/job/presentation/swagger/JobSwagger.java
@@ -3,11 +3,13 @@ package com.dodream.job.presentation.swagger;
 import com.dodream.core.config.swagger.ApiErrorCode;
 import com.dodream.core.infrastructure.security.CustomUserDetails;
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.job.domain.TodoCategory;
 import com.dodream.job.dto.request.recommend.OnboardingAnswerSet;
 import com.dodream.job.dto.response.JobAddListDto;
 import com.dodream.job.dto.response.JobListDto;
 import com.dodream.job.dto.response.JobRecommendationResponse;
 import com.dodream.job.dto.response.JobResponseDto;
+import com.dodream.job.dto.response.JobTodoListResponseDto;
 import com.dodream.job.exception.JobErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -73,4 +75,14 @@ public interface JobSwagger {
         operationId = "/v1/job/add"
     )
     ResponseEntity<RestResponse<List<JobAddListDto>>> getJobAddList();
+
+
+    @Operation(
+        summary = "특정 직업의 카테고리별 투두 조회 API",
+        description = "특정 직업의 카테고리별 투두를 반환합니다.",
+        operationId = "/v1/job/todo"
+    )
+    ResponseEntity<RestResponse<JobTodoListResponseDto>> getJobTodoList(
+        @RequestParam("id") Long id,
+        @RequestParam("todoCategory") TodoCategory todoCategory);
 }

--- a/src/main/java/com/dodream/job/repository/JobTodoRepository.java
+++ b/src/main/java/com/dodream/job/repository/JobTodoRepository.java
@@ -2,10 +2,13 @@ package com.dodream.job.repository;
 
 import com.dodream.job.domain.Job;
 import com.dodream.job.domain.JobTodo;
+import com.dodream.job.domain.TodoCategory;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JobTodoRepository extends JpaRepository<JobTodo, Long> {
 
     List<JobTodo> findAllByJob(Job job);
+
+    List<JobTodo> findByJobAndTodoCategory(Job job, TodoCategory todoCategory);
 }

--- a/src/main/java/com/dodream/todo/dto/response/GetOneTodoGroupResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOneTodoGroupResponseDto.java
@@ -51,6 +51,6 @@ public record GetOneTodoGroupResponseDto(
 
     public static GetOneTodoGroupResponseDto empty(Member member) {
         return new GetOneTodoGroupResponseDto(null, member.getNickName(), null,null, null, null,
-            null, null, Collections.emptyList());
+            null,null, Collections.emptyList());
     }
 }

--- a/src/main/java/com/dodream/todo/dto/response/GetOneTodoGroupResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOneTodoGroupResponseDto.java
@@ -21,8 +21,6 @@ public record GetOneTodoGroupResponseDto(
     String regionName,
     @Schema(description = "투두 경과 일자(X일)", example = "38")
     Long daysAgo,
-    @Schema(description = "직업 이름", example = "요양보호사")
-    String jobName,
     @Schema(description = "직업 id", example = "1")
     Long jobId,
     @Schema(description = "조회수", example = "101")
@@ -42,7 +40,6 @@ public record GetOneTodoGroupResponseDto(
             .daysAgo(
                 ChronoUnit.DAYS.between(myTodoGroup.getCreatedAt().toLocalDate(), LocalDate.now())
                     + 1)
-            .jobName(myTodoGroup.getJob().getJobName())
             .jobId(myTodoGroup.getJob().getId())
             .totalView(myTodoGroup.getTotalView())
             .todos(todos)
@@ -51,6 +48,6 @@ public record GetOneTodoGroupResponseDto(
 
     public static GetOneTodoGroupResponseDto empty(Member member) {
         return new GetOneTodoGroupResponseDto(null, member.getNickName(), null,null, null, null,
-            null,null, Collections.emptyList());
+            null, Collections.emptyList());
     }
 }

--- a/src/main/java/com/dodream/todo/dto/response/GetOneTodoGroupResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOneTodoGroupResponseDto.java
@@ -21,6 +21,8 @@ public record GetOneTodoGroupResponseDto(
     String regionName,
     @Schema(description = "투두 경과 일자(X일)", example = "38")
     Long daysAgo,
+    @Schema(description = "직업 이름", example = "요양보호사")
+    String jobName,
     @Schema(description = "직업 id", example = "1")
     Long jobId,
     @Schema(description = "조회수", example = "101")
@@ -40,6 +42,7 @@ public record GetOneTodoGroupResponseDto(
             .daysAgo(
                 ChronoUnit.DAYS.between(myTodoGroup.getCreatedAt().toLocalDate(), LocalDate.now())
                     + 1)
+            .jobName(myTodoGroup.getJob().getJobName())
             .jobId(myTodoGroup.getJob().getId())
             .totalView(myTodoGroup.getTotalView())
             .todos(todos)
@@ -48,6 +51,6 @@ public record GetOneTodoGroupResponseDto(
 
     public static GetOneTodoGroupResponseDto empty(Member member) {
         return new GetOneTodoGroupResponseDto(null, member.getNickName(), null,null, null, null,
-            null, Collections.emptyList());
+            null, null, Collections.emptyList());
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 📝 작업 내용
- 직업별 단계별 투두 리스트 조회 api를 구현하다.

## ✏️ 관련 이슈
#251 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - GET /v1/job/todo?id={id}&todoCategory={카테고리} 추가: 특정 직무의 카테고리별 할 일 목록 조회
  - 응답에 직무 정보(아이디, 이름), 선택한 카테고리 및 해당 할 일 항목 포함
- 보안
  - /v1/job/todo/** 경로를 허용 목록에 추가하여 인증 없이 접근 가능
- 문서
  - API 문서에 신규 엔드포인트, 요청 파라미터 및 응답 스키마 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->