### PR TITLE
Feat(#263) : 홈페이지 인기있는 투두 조회 api 구현

### DIFF
--- a/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/dodream/core/config/security/SecurityConfiguration.java
@@ -37,7 +37,8 @@ public class SecurityConfiguration {
         "/v1/job/**",
         "/v1/todo/other/public",
         "/v1/job/todo/**",
-        "/v1/community/**"
+        "/v1/community/**",
+        "/v1/todo/popular"
     };
 
     @Bean

--- a/src/main/java/com/dodream/todo/application/TodoService.java
+++ b/src/main/java/com/dodream/todo/application/TodoService.java
@@ -7,6 +7,7 @@ import com.dodream.member.application.MemberAuthService;
 import com.dodream.member.domain.Member;
 import com.dodream.todo.domain.Todo;
 import com.dodream.todo.domain.TodoGroup;
+import com.dodream.todo.dto.response.GetOnePopularTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoWithMemoResponseDto;
@@ -18,6 +19,7 @@ import com.dodream.todo.repository.TodoRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -62,21 +64,21 @@ public class TodoService {
     }
 
     // [비로그인 상태] 홈화면에서 드리머 투두 리스트 간편 조회(3개씩)
-     @Transactional(readOnly = true)
-     public List<GetOthersTodoGroupResponseDto> getOneTodoGroupPublicAtHome() {
+    @Transactional(readOnly = true)
+    public List<GetOthersTodoGroupResponseDto> getOneTodoGroupPublicAtHome() {
 
-         Pageable limit3 = PageRequest.of(0, 3);
-         List<TodoGroup> todoGroups = todoGroupRepository.findTop3ByTotalView(limit3);
+        Pageable limit3 = PageRequest.of(0, 3);
+        List<TodoGroup> todoGroups = todoGroupRepository.findTop3ByTotalView(limit3);
 
-         Pageable top2 = PageRequest.of(0, 2);
-         return todoGroups.stream()
-             .map(group -> {
-                 List<Todo> todos = todoRepository.findTop2ByTodoGroup(group, top2);
-                 Long todoCount = todoRepository.countByTodoGroup(group);
-                 return GetOthersTodoGroupResponseDto.of(group, todos, todoCount);
-             })
-             .toList();
-     }
+        Pageable top2 = PageRequest.of(0, 2);
+        return todoGroups.stream()
+            .map(group -> {
+                List<Todo> todos = todoRepository.findTop2ByTodoGroup(group, top2);
+                Long todoCount = todoRepository.countByTodoGroup(group);
+                return GetOthersTodoGroupResponseDto.of(group, todos, todoCount);
+            })
+            .toList();
+    }
 
 
     // 특정 직업 정보 페이지 - 우측 상단에 타유저 리스트
@@ -143,7 +145,19 @@ public class TodoService {
             .map(GetOneTodoResponseDto::from)
             .toList();
 
-        return GetOneTodoGroupResponseDto.of(todoGroup.getMember(),todoGroup, todos);
+        return GetOneTodoGroupResponseDto.of(todoGroup.getMember(), todoGroup, todos);
     }
 
+
+    // 홈화면 - 인기 투두 조회
+    @Transactional
+    public List<GetOnePopularTodoGroupResponseDto> getPopularTodos() {
+
+        // 최대로 많이 담긴 3개의 todoGroup 가져온다
+        List<Todo> todos = todoRepository.findTop3ByOrderBySaveCountDesc();
+
+        return todos.stream()
+            .map(GetOnePopularTodoGroupResponseDto::from)
+            .toList();
+    }
 }

--- a/src/main/java/com/dodream/todo/application/TodoService.java
+++ b/src/main/java/com/dodream/todo/application/TodoService.java
@@ -153,7 +153,6 @@ public class TodoService {
     @Transactional
     public List<GetOnePopularTodoGroupResponseDto> getPopularTodos() {
 
-        // 최대로 많이 담긴 3개의 todoGroup 가져온다
         List<Todo> todos = todoRepository.findTop3ByOrderBySaveCountDesc();
 
         return todos.stream()

--- a/src/main/java/com/dodream/todo/dto/response/GetOnePopularTodoGroupResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/GetOnePopularTodoGroupResponseDto.java
@@ -1,0 +1,39 @@
+package com.dodream.todo.dto.response;
+
+import com.dodream.todo.domain.Todo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record GetOnePopularTodoGroupResponseDto(
+    @Schema(description = "투두 id", example = "12")
+    Long todoId,
+    @Schema(description = "투두 제목", example = "요양보호사 자격증 준비하기")
+    String title,
+    @Schema(description = "멤버 프로필 사진", example = "www.~")
+    String profileImage,
+    @Schema(description = "멤버 닉네임", example = "두둠칫")
+    String memberNickname,
+    @Schema(description = "멤버 단계", example = "새싹 단계")
+    String memberLevel,
+    @Schema(description = "직업 이름", example = "요양보호사")
+    String jobName,
+    @Schema(description = "담은수 ", example = "101")
+    Long saveCount
+) {
+
+    public static GetOnePopularTodoGroupResponseDto from(Todo todo) {
+        return GetOnePopularTodoGroupResponseDto.builder()
+            .todoId(todo.getId())
+            .title(todo.getTitle())
+            .profileImage(todo.getMember().getProfileImage() == null ? null
+                : todo.getMember().getProfileImage())
+            .memberNickname(todo.getMember().getNickName())
+            .memberLevel(
+                todo.getMember().getLevel() == null ? null : todo.getMember().getLevel().getValue())
+            .jobName(todo.getTodoGroup().getJob().getJobName())
+            .saveCount(todo.getSaveCount())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
+++ b/src/main/java/com/dodream/todo/presentation/controller/TodoController.java
@@ -2,6 +2,7 @@ package com.dodream.todo.presentation.controller;
 
 import com.dodream.core.presentation.RestResponse;
 import com.dodream.todo.application.TodoService;
+import com.dodream.todo.dto.response.GetOnePopularTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoWithMemoResponseDto;
 import com.dodream.todo.dto.response.GetOthersTodoGroupResponseDto;
@@ -63,5 +64,11 @@ public class TodoController implements TodoSwagger {
             new RestResponse<>(todoService.getOneOthersTodoGroup(todoGroupId)));
     }
 
+    @Override
+    @GetMapping(value = "/popular")
+      public ResponseEntity<RestResponse<List<GetOnePopularTodoGroupResponseDto>>> getPopularTodos(){
+          return ResponseEntity.ok(
+              new RestResponse<>(todoService.getPopularTodos()));
+      }
 
 }

--- a/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
+++ b/src/main/java/com/dodream/todo/presentation/swagger/TodoSwagger.java
@@ -2,6 +2,7 @@ package com.dodream.todo.presentation.swagger;
 
 import com.dodream.core.config.swagger.ApiErrorCode;
 import com.dodream.core.presentation.RestResponse;
+import com.dodream.todo.dto.response.GetOnePopularTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoGroupResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoResponseDto;
 import com.dodream.todo.dto.response.GetOneTodoWithMemoResponseDto;
@@ -64,5 +65,12 @@ public interface TodoSwagger {
     ResponseEntity<RestResponse<GetOneTodoGroupResponseDto>> getOneOthersTodoGroup(
         @PathVariable Long todoGroupId);
 
+    @Operation(
+        summary = "인기 투두 조회 API",
+        description = "인기 있는 투두 3개 조회",
+        operationId = "/v1/todo/popular"
+    )
+    @ApiErrorCode(TodoErrorCode.class)
+    ResponseEntity<RestResponse<List<GetOnePopularTodoGroupResponseDto>>> getPopularTodos();
 
 }

--- a/src/main/java/com/dodream/todo/repository/TodoRepository.java
+++ b/src/main/java/com/dodream/todo/repository/TodoRepository.java
@@ -28,4 +28,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, TodoRepositor
     Optional<Todo> findByOtherTodoIdAndMember(Long otherTodoId, Member member);
 
     boolean existsByMemberAndOtherTodoId(Member member, Long otherTodoId);
+
+    List<Todo> findTop3ByOrderBySaveCountDesc();
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용
-  홈페이지 인기있는 투두 조회 api 구현

## ✏️ 관련 이슈
#263 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 인기 투두 조회 API 추가: /v1/todo/popular
  - 저장 수 기준 상위 3개 투두를 제공하며 로그인 없이 이용 가능합니다.
  - 응답에 투두 ID, 제목, 작성자 닉네임/레벨, 직무, 프로필 이미지, 저장 수 포함.

- 문서
  - Swagger에 인기 투두 조회 API 명세를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->