### PR TITLE
Bugfix (#273) : 커뮤니티 투두 조회 에러 처리

### DIFF
--- a/src/main/java/com/dodream/todo/dto/response/TodoCommunityResponseDto.java
+++ b/src/main/java/com/dodream/todo/dto/response/TodoCommunityResponseDto.java
@@ -41,7 +41,7 @@ public record TodoCommunityResponseDto(
             response.id(),
             response.todoGroupId(),
             response.name(),
-            response.level() == null ? "새싹 단계" : response.level().getValue(),
+            response.level() == null ? null : response.level().getValue(),
             response.imageUrl(),
             ConvertLocalDateToString.calculateTimeAgo(response.createdAt()),
             response.description(),

--- a/src/main/java/com/dodream/todo/repository/TodoRepositoryImpl.java
+++ b/src/main/java/com/dodream/todo/repository/TodoRepositoryImpl.java
@@ -81,6 +81,7 @@ public class TodoRepositoryImpl implements TodoRepositoryCustom{
                 .select(Projections.constructor(
                         TodoCommunityResponse.class,
                         todo.id,
+                        todo.todoGroup.id,
                         member.nickName,
                         member.level,
                         member.profileImage,


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

- 커뮤니티 투두 조회 에러 처리 (todoGroupId querydsl에 추가)

## ✏️ 관련 이슈
#273 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 커뮤니티 할 일 목록 응답에 할 일 그룹 ID가 추가되어, 항목별 소속 그룹을 식별하고 그룹 기반의 이동/연결이 가능해졌습니다.
  - 그룹 ID 노출로 향후 그룹별 필터링, 상세 보기로의 빠른 전환 등 사용 흐름이 더 원활해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->